### PR TITLE
Add health checks for multiple coin pool server

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -10,6 +10,7 @@ const net = require('net');
 const tls = require('tls');
 const fs = require('fs');
 const child_process = require('child_process');
+const disk = require('diskusage');
 
 let nonceCheck = new RegExp("^[0-9a-f]{8}$");
 let bannedIPs = {};
@@ -49,6 +50,44 @@ const VER_SHARES_PERIOD = 5;
 Buffer.prototype.toByteArray = function () {
     return Array.prototype.slice.call(this, 0);
 };
+
+function toGB(x) { return (x / (1024 * 1024 * 1024)).toFixed(1); }
+
+// Disk monitor
+function diskfree(path) {
+	let avail = -2;
+	disk.check(path, function(err, info) {
+		if (err) {
+			avail = -1;
+		} else {
+			avail = toGB(info.available);
+		}
+	});
+	return avail;
+}
+
+// CPU Monitor
+function CPULoad() {
+	let totalLoad = require('os').loadavg();
+	return totalLoad[2]/require('os').cpus().length;
+}
+
+function healthCheck() {
+	if (diskfree("/") < 5) {
+		global.support.sendEmail(
+			global.config.general.adminEmail,
+			sprintf(global.config.hostname+' - NOT OK - LOW DISK GB : / '+diskfree("/")),
+			`(${global.config.hostname}) Please delete something.`
+		);		
+	}
+	if (CPULoad() > 0.8) {
+		global.support.sendEmail(
+			global.config.general.adminEmail,
+			sprintf(global.config.hostname+' - NOT OK - HIGH CPU USAGE : '+CPULoad().toFixed(2)),
+			`(${global.config.hostname}) Please check server.`
+		);	
+	}
+}
 
 if (cluster.isMaster) {
     threadName = "(Master) ";
@@ -1622,6 +1661,7 @@ if (cluster.isMaster) {
     templateUpdate("");
     setTimeout(templateUpdate, 50, "", true);
     global.support.sendEmail(global.config.general.adminEmail, "Pool server " + global.config.hostname + " online", "The pool server: " + global.config.hostname + " with IP: " + global.config.bind_ip + " is online");
+    setInterval(healthCheck, 4*60*60*1000); // every 4 hours
 } else {
     templateUpdate("");
     if (global.config.daemon.activePortHeavy && global.config.daemon.activePortLight) {


### PR DESCRIPTION
In package.json , add "diskusage": "^0.2.4",
I'm running multiple coins pool (not as same as yours) and I think we need server's regular health check (Disk, CPU, RAM). For RAM, the os.freemem() can not be used at the moment, it doesn't give correct info about real free memory. 
I'm using these codes on my server and want to contribute just in case you think it is useful for your multiple coins pool.