### PR TITLE
Not sure if neccessary any more.

### DIFF
--- a/lib/local_comms.js
+++ b/lib/local_comms.js
@@ -654,7 +654,7 @@ function Database(){
             for (let found = cursor.goToFirst(); found; found = cursor.goToNext()) {
                  cursor.getCurrentBinary(function(key, data){  // jshint ignore:line
                      let blockData = global.protos.AltBlock.decode(data);
-                     if (blockData.unlocked === false){
+                     if (blockData.unlocked === false && blockData.valid){
                          if (oldestLockedBlockHeight === null || oldestLockedBlockHeight > blockData.anchor_height) {
                              oldestLockedBlockHeight = blockData.anchor_height;
                          }
@@ -669,7 +669,7 @@ function Database(){
                  cursor.getCurrentBinary(function(key, data){  // jshint ignore:line
                      if (oldestLockedBlockHeight !== null && oldestLockedBlockHeight <= key) return;
                      let blockData = global.protos.Block.decode(data);
-                     if (blockData.unlocked === false) {
+                     if (blockData.unlocked === false && blockData.valid) {
                          oldestLockedBlockHeight = key;
                      }
                  });


### PR DESCRIPTION
I see you put err check in the code so this PR is not really necessary. Just for logic.
We will get oldestLockedBlockHeight for good (not orphan) block.
Discard PR if you don't like it.