### PR TITLE
Only let one cleanshare instance

### DIFF
--- a/lib/local_comms.js
+++ b/lib/local_comms.js
@@ -3,6 +3,7 @@ let range = require('range');
 let debug = require('debug')('db');
 let async = require('async');
 let cleanShareInProgress = false;
+let cleanShareStuckCount = 0;
 
 function poolTypeStr(poolType) {
     switch (poolType) {
@@ -715,6 +716,8 @@ function Database(){
          */
 	if (cleanShareInProgress) {
 		console.error("CleanShareDB already running");
+		++cleanShareStuckCount;
+		if (cleanShareStuckCount > 5) global.support.sendEmail(global.config.general.adminEmail,"LongRunner stuck",cleanShareStuckCount);
 		return ; // already running
 	}
 	cleanShareInProgress = true;
@@ -832,10 +835,10 @@ function Database(){
                 }
                 global.database.env.sync(function(){
                 });
-		cleanShareInProgress = false;
+		cleanShareInProgress = false; cleanShareStuckCount = 0;
             } else {
                 console.log("Block cleaning disabled.  Would have removed: " + JSON.stringify(data));
-		cleanShareInProgress = false;
+		cleanShareInProgress = false; cleanShareStuckCount = 0;
             }
             console.log("Done cleaning up the share DB");
         });

--- a/lib/local_comms.js
+++ b/lib/local_comms.js
@@ -2,6 +2,7 @@
 let range = require('range');
 let debug = require('debug')('db');
 let async = require('async');
+let cleanShareInProgress = false;
 
 function poolTypeStr(poolType) {
     switch (poolType) {
@@ -712,6 +713,11 @@ function Database(){
          where there's unlocked blocks.  A find on the current block will have enough depth as long as the saves are
          correct.  This will cause the system to clean up shares massively when there are no unlocked blocks.
          */
+	if (cleanShareInProgress) {
+		console.error("CleanShareDB already running");
+		return ; // already running
+	}
+	cleanShareInProgress = true;
         let oldestLockedBlockHeight = this.getOldestLockedBlockHeight();
         async.waterfall([
             function(callback){
@@ -826,8 +832,10 @@ function Database(){
                 }
                 global.database.env.sync(function(){
                 });
+		cleanShareInProgress = false;
             } else {
                 console.log("Block cleaning disabled.  Would have removed: " + JSON.stringify(data));
+		cleanShareInProgress = false;
             }
             console.log("Done cleaning up the share DB");
         });


### PR DESCRIPTION
if cleanshare is stuck or long, it won't cause multiple instances.