### PR TITLE
Add sendEmail to Admin for simpler code

### DIFF
--- a/lib/support.js
+++ b/lib/support.js
@@ -110,7 +110,7 @@ function sendEmail(toAddress, subject, body, wallet){
 }
 
 function sendEmailAdmin(subject, body){
-	if (subject.indexOf("FYI") === -1) {
+	if (subject.includes("FYI")) {
 		sendEmailReal(global.config.general.adminEmail, subject, body);
 	} else {
 		sendEmail(global.config.general.adminEmail, subject, body);

--- a/lib/support.js
+++ b/lib/support.js
@@ -109,6 +109,14 @@ function sendEmail(toAddress, subject, body, wallet){
     }
 }
 
+function sendEmailAdmin(subject, body){
+	if (subject.indexOf("FYI") === -1) {
+		sendEmailReal(global.config.general.adminEmail, subject, body);
+	} else {
+		sendEmail(global.config.general.adminEmail, subject, body);
+	}
+}
+
 function jsonRequest(host, port, data, is_wallet, callback, path, timeout) {
     let uri;
     if (global.config.rpc.https) {
@@ -339,6 +347,7 @@ module.exports = function () {
         formatDateFromSQL: formatDateFromSQL,
         blockCompare: blockCompare,
         sendEmail: sendEmail,
+	sendEmailAdmin: sendEmailAdmin,
         tsCompare: tsCompare,
         getAlgoHashFactor: getAlgoHashFactor,
 	getActivePort: getActivePort,


### PR DESCRIPTION
With this function, we can make code shorter by avoiding repeating global.config.general.adminEmail parameter.