### PR TITLE
"Drown in waterfall" bug, finally gotcha

### DIFF
--- a/lib/local_comms.js
+++ b/lib/local_comms.js
@@ -730,7 +730,7 @@ function Database(){
                     global.coinFuncs.getBlockHeaderByID(oldestLockedBlockHeight, (err, result) => {
                         if (err !== null) {
                             console.error("Can't get block with " + oldestLockedBlockHeight + " height");
-                            return;
+                            return callback(true);
                         }
                         callback(null, oldestLockedBlockHeight, result.difficulty);
                     });
@@ -740,7 +740,7 @@ function Database(){
                 global.coinFuncs.getLastBlockHeader(function(err, body){
                     if (err !== null) {
                         console.error("Last block header request failed!");
-                        return;
+                        return callback(true);
                     }
                     if (oldestLockedBlockHeight === null){
                         /*
@@ -812,6 +812,10 @@ function Database(){
                 callback(null, Array.from(Object.keys(blockSet)));
             }
         ], function(err, data){
+            if (err !== null) {
+		    console.error("ERROR with cleaning up because of daemon stuck");
+		    return;
+	    }
             if (global.config.general.blockCleaner === true){
                 if(data.length > 0){
                     global.database.refreshEnv();

--- a/lib/local_comms.js
+++ b/lib/local_comms.js
@@ -814,6 +814,7 @@ function Database(){
         ], function(err, data){
             if (err !== null) {
 		    console.error("ERROR with cleaning up because of daemon stuck");
+		    cleanShareInProgress = false;
 		    return;
 	    }
             if (global.config.general.blockCleaner === true){


### PR DESCRIPTION
Finally, I can trace back the database explosion (turtlecoin unstability, graft under attack, electroneum under attack) issue because of longRunner stuck that I didn't notice. The probability to occur is very slim with normal network (only if you restart daemon par hazard at the same time longRunner starts).

Steps to reproduce longRunner stuck :
Step 1 : Stop coin daemon
Step 2 : Start longRunner
Step 3 : Start coin daemon 

Expected : cleanShareDB exits when daemon request fails.
Observation : cleanShareDB got stuck in waterfall and never exits even when coin daemon come back to normal.
if my codes doesn't look well, feel free to correct them.