### PR TITLE
Send mail if worker restarted.

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -1715,6 +1715,10 @@ if (cluster.isMaster) {
         console.log('Starting a new worker');
         worker = cluster.fork();
         worker.on('message', messageHandler);
+        if (worker.id > 8){
+            global.support.sendEmail(global.config.general.adminEmail, "Started new worker " + worker.id,
+            "Hello,\r\nMaster theread starts new worker with id " + worker.id);
+        };
     });
 
 

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -1715,10 +1715,8 @@ if (cluster.isMaster) {
         console.log('Starting a new worker');
         worker = cluster.fork();
         worker.on('message', messageHandler);
-        if (worker.id > 8){
-            global.support.sendEmail(global.config.general.adminEmail, "Started new worker " + worker.id,
+        global.support.sendEmail(global.config.general.adminEmail, "FYI: Started new worker " + worker.id,
             "Hello,\r\nMaster theread starts new worker with id " + worker.id);
-        };
     });
 
 


### PR DESCRIPTION
Before fix about WorkerList if a worker died master thread died too. And after restart master thread sends mail with "Pool online".
Now if we have a bug or something worker will be died in circles and we don't know about it.