### PR TITLE
Fix mistake

### DIFF
--- a/lib/payment_systems/xmr.js
+++ b/lib/payment_systems/xmr.js
@@ -699,7 +699,6 @@ function makePayments() {
         console.log("Loaded all payees into the system for processing");
         let paymentDestinations = [];
         let totalAmount = 0;
-        let payeeList = [];
         let payeeObjects = {};
         async.eachSeries(rows, function(row, next) {
             //debug("Starting round for: " + JSON.stringify(row));
@@ -727,21 +726,23 @@ function makePayments() {
                 }
                 if (payee.amount >= threshold) {
                     payee.setFeeAmount();
-                    payeeObjects[payee.id] = payee;
                     if (payee.bitcoin === 0 && payee.paymentID === null && payee.amount !== 0 && payee.amount > 0 && payee.address.length !== 106) {
+                        payeeObjects[payee.id] = payee;
                         console.log("[++] " + payee.id + " miner to bulk payment. Amount: " + global.support.coinToDecimal(payee.amount));
                         paymentDestinations.push({amount: payee.amount - payee.fee, address: payee.address});
                         totalAmount += payee.amount;
-                        payeeList.push(payee);
                     } else if (payee.bitcoin === 0 && payee.paymentID === null && payee.amount !== 0 && payee.amount > 0 && payee.address.length === 106 && (payee.amount >= global.support.decimalToCoin(global.config.payout.exchangeMin) || (payee.amount > threshold && custom_threshold))) {
                         // Special code to handle integrated payment addresses.  What a pain in the rear.
                         // These are exchange addresses though, so they need to hit the exchange payout amount.
+                        payeeObjects[payee.id] = payee;
                         console.log("[+] " + payee.id + " as separate payment to integrated address. Amount: " + global.support.coinToDecimal(payee.amount));
                         payee.makePaymentAsIntegrated();
                     } else if ((payee.amount >= global.support.decimalToCoin(global.config.payout.exchangeMin) || (payee.amount > threshold && custom_threshold)) && payee.bitcoin === 0) {
+                        payeeObjects[payee.id] = payee;
                         console.log("[+] " + payee.id + " as separate payment to payment ID address. Amount: " + global.support.coinToDecimal(payee.amount));
                         payee.makePaymentWithID();
                     } else if ((payee.amount >= global.support.decimalToCoin(global.config.payout.exchangeMin) || (payee.amount > threshold && custom_threshold)) && payee.bitcoin === 1) {
+                        payeeObjects[payee.id] = payee;
                         console.log("[+] " + payee.id + " as separate payment to bitcoin. Amount: " + global.support.coinToDecimal(payee.amount));
                         payee.makeBitcoinPayment();
                     }


### PR DESCRIPTION
If a miner has more than walletMin and less than exchangeMin on first balance and payment address type is exchange wallet. second balance more than exchangeMin they don't get coins.
payeeList don't use var