### PR TITLE
Add "perf" option to set starting diff based on algo-perf

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -972,6 +972,16 @@ function Miner(id, login, pass, rigid, ipAddress, startingDiff, pushMessage, pro
     if (login_diff_split.length === 2) {
         this.fixed_diff = true;
         this.difficulty = Number(login_diff_split[1]);
+        if (login_diff_split[1].substring(0, 4) === 'perf') {
+            let perfDiff = 0;
+            if (this.coin_perf[""] > 2) {
+                perfDiff = Math.floor(this.coin_perf[""] * (global.config.pool.targetTime || 30));
+            }
+            if (login_diff_split[1].substring(4, 8) === 'auto' || perfDiff === 0) {
+                this.fixed_diff = false;
+            }
+            this.difficulty = perfDiff || startingDiff;
+        }
         if (this.difficulty < global.config.pool.minDifficulty) {
             this.difficulty = global.config.pool.minDifficulty;
         }


### PR DESCRIPTION
* overrides default connection-port-based starting diff
* append "+perf" to login/user (fixed-diff)
* append "+perfauto" to login/user (auto-diff)
* append "+123456" for existing fixed-diff support
* anything else falls back to ignoring the "+" section (auto port-diff)