### PR TITLE
Fix task queue reentrant pumping

### DIFF
--- a/lib/common/callbacks.js
+++ b/lib/common/callbacks.js
@@ -2,6 +2,7 @@
 function createTaskQueue(concurrency, worker) {
     const pending = [];
     let running = 0;
+    let pumping = false;
 
     function enqueue(method, data, callback) {
         pending[method]({ data, callback });
@@ -9,6 +10,8 @@ function createTaskQueue(concurrency, worker) {
     }
 
     function pump() {
+        if (pumping) return;
+        pumping = true;
         while (running < concurrency && pending.length) {
             const task = pending.shift();
             running += 1;
@@ -18,6 +21,7 @@ function createTaskQueue(concurrency, worker) {
                 pump();
             });
         }
+        pumping = false;
     }
 
     return {

--- a/tests/all.js
+++ b/tests/all.js
@@ -11,6 +11,7 @@ require("./remote_share.js");
 require("./api.js");
 require("./support.js");
 require("./local_comms.js");
+require("./common/callbacks.js");
 require("./live_helpers.js");
 require("./live.js");
 require("./payments.js");

--- a/tests/common/callbacks.js
+++ b/tests/common/callbacks.js
@@ -1,0 +1,33 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const { createTaskQueue } = require("../../lib/common/callbacks.js");
+
+test.describe("callbacks", { concurrency: false }, () => {
+    test("createTaskQueue handles synchronous completions without recursive pump overflow", async () => {
+        const blocked = [];
+        let completed = 0;
+        const queue = createTaskQueue(16, function processTask(task, done) {
+            if (task.block) {
+                blocked.push(done);
+                return;
+            }
+            completed += 1;
+            done();
+        });
+
+        for (let index = 0; index < 16; ++index) queue.push({ block: true });
+        for (let index = 0; index < 30000; ++index) queue.push({ block: false });
+
+        assert.equal(queue.running(), 16);
+        assert.equal(queue.length(), 30000);
+        assert.equal(blocked.length, 16);
+
+        blocked.pop()();
+        assert.equal(completed, 30000);
+        assert.equal(queue.length(), 0);
+        assert.equal(queue.running(), 15);
+    });
+});


### PR DESCRIPTION
### Motivation
- The custom `createTaskQueue` pumped tasks synchronously from the worker completion callback, allowing synchronous completions to recursively re-enter `pump()` and eventually trigger `RangeError: Maximum call stack size exceeded` under large backlogs (e.g. expired remote share-verification tasks). 
- Preventing reentrant `pump()` execution preserves service availability and avoids a remote-triggerable crash without changing existing queue semantics.

### Description
- Add a reentrancy guard `pumping` to `createTaskQueue` so `pump()` returns immediately if already running, and clear the guard when the loop finishes. 
- Keep existing behavior of immediately scheduling work while ensuring synchronous worker callbacks cannot cause unbounded recursion in `pump()`. 
- Add a regression test `tests/common/callbacks.js` that simulates 16 blocked workers and 30,000 synchronous-completion tasks and verifies the queue drains without stack overflow. 
- Include the new test in the test aggregator by requiring `./common/callbacks.js` from `tests/all.js`.

### Testing
- Ran the new regression test with `node --test tests/common/callbacks.js`, and it passed. 
- Attempted full test run with `npm test`, which failed in this environment due to a missing dev dependency (`Error: Cannot find module 'protocol-buffers'`), not because of the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0b8cd7afec8321af776e1ad2722be4)