### PR TITLE
Reject zero-hash trusted shares

### DIFF
--- a/lib/pool/state.js
+++ b/lib/pool/state.js
@@ -222,10 +222,10 @@ module.exports = function createPoolState() {
     function divideBaseDiff(diff) {
         const baseDiff = toBigInt(global.coinFuncs.baseDiff());
         const divisor = toBigInt(diff);
-        // Buggy miners can submit an all-zero result hash. Treat that as the
-        // highest possible share difficulty so the normal verifier can reject
-        // it cleanly instead of crashing the socket handler on division by zero.
-        if (divisor === 0n) return baseDiff;
+        // Buggy miners can submit an all-zero result hash. Treat that as zero
+        // difficulty so trusted-share accounting cannot credit forged work,
+        // while still avoiding a division-by-zero crash in the verifier.
+        if (divisor === 0n) return 0n;
         return baseDiff / divisor;
     }
 

--- a/tests/pool/runtime/trust.js
+++ b/tests/pool/runtime/trust.js
@@ -95,6 +95,57 @@ test("trusted miners can take the trusted-share fast path", async () => {
     }
 });
 
+test("trusted miners cannot credit all-zero result hashes", async () => {
+    const { runtime } = await startHarness();
+    const originalTrustedMiners = global.config.pool.trustedMiners;
+    const originalRandomBytes = crypto.randomBytes;
+    const socket = {};
+
+    try {
+        global.config.pool.trustedMiners = true;
+        crypto.randomBytes = () => Buffer.from([255]);
+
+        const loginReply = invokePoolMethod({
+            socket,
+            id: 197,
+            method: "login",
+            params: {
+                login: MAIN_WALLET,
+                pass: "worker-trusted-zero-hash"
+            }
+        });
+
+        const state = runtime.getState();
+        const miner = state.activeMiners.get(socket.miner_id);
+        const jobId = loginReply.replies[0].result.job.job_id;
+        state.walletTrust[MAIN_WALLET] = 1000;
+        miner.trust.trust = 1000;
+        miner.trust.check_height = 0;
+
+        const submitReply = invokePoolMethod({
+            socket,
+            id: 198,
+            method: "submit",
+            params: {
+                id: socket.miner_id,
+                job_id: jobId,
+                nonce: "0000000a",
+                result: ZERO_RESULT
+            }
+        });
+
+        await flushTimers();
+        assert.deepEqual(submitReply.replies, [{ error: "Low difficulty share", result: undefined }]);
+        assert.equal(runtime.getState().shareStats.trustedShares, 0);
+        assert.equal(runtime.getState().shareStats.normalShares, 0);
+        assert.equal(runtime.getState().shareStats.invalidShares, 1);
+    } finally {
+        global.config.pool.trustedMiners = originalTrustedMiners;
+        crypto.randomBytes = originalRandomBytes;
+        await runtime.stop();
+    }
+});
+
 test("invalid shares clear local trust for same-wallet active miners when wallet trust drops", async () => {
     const { runtime } = await startHarness();
     const originalTrustedMiners = global.config.pool.trustedMiners;


### PR DESCRIPTION
### Motivation
- A change to `divideBaseDiff()` previously mapped an all-zero submitted result hash to `baseDiff`, which made forged zero-result hashes appear to meet any difficulty and allowed trusted miners to receive credit without doing work. 
- The pool enables `trustedMiners` by default, so this regression could be exploited by trusted miners to get PPLNS credit for all-zero results.

### Description
- Update `divideBaseDiff()` in `lib/pool/state.js` to return `0n` when the divisor is zero, preventing all-zero result hashes from appearing to have high difficulty while avoiding division-by-zero. 
- Add a regression test in `tests/pool/runtime/trust.js` that enables the trusted-miner fast path, submits `ZERO_RESULT` (all-zero result), and asserts the share is rejected and not credited as trusted or normal. 
- Preserve existing behavior for non-zero divisors (`baseDiff / divisor`).

### Testing
- Performed static checks with `node --check lib/pool/state.js && node --check tests/pool/runtime/trust.js`, which succeeded. 
- Executed a small Node script that exercises `divideBaseDiff()` directly (calling the exported state and checking zero/non-zero divisor behavior), which passed. 
- Attempted to run the full test harness (`node --require ./tests/common/test_output_buffer.js --test ... tests/pool/runtime/trust.js`), but it failed due to a missing dependency `protocol-buffers` and could not complete. 
- Attempted `npm install` to restore test dependencies, but it was blocked by registry access (`403 Forbidden` for `crypto-js`), preventing a full test run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0b913e3db08321a80f875a2b67ff03)