### PR TITLE
Ensure unique ETH worker IDs by removing eth_pool_support bypass

### DIFF
--- a/lib/pool/lifecycle.js
+++ b/lib/pool/lifecycle.js
@@ -78,7 +78,6 @@ module.exports = function createLifecycle(deps) {
     }
 
     function getUniqueWorkerID(callback) {
-        if (!global.config.eth_pool_support) return callback(0, 1);
         global.mysql.query("SELECT id FROM pool_workers WHERE pool_id = ? AND worker_id = ?", [global.config.pool_id, process.env.WORKER_ID]).then(function onRows(rows) {
             if (rows.length === 0) {
                 global.mysql.query("INSERT INTO pool_workers (pool_id, worker_id) VALUES (?, ?) ON DUPLICATE KEY UPDATE id=id", [global.config.pool_id, process.env.WORKER_ID]).then(function retry() {


### PR DESCRIPTION
### Motivation
- An early return in `getUniqueWorkerID` bypassed database-backed worker ID allocation when `global.config.eth_pool_support` was unset or false, which caused multiple worker processes to initialize identical `uniqueWorkerId` values and collide ETH extranonce spaces, enabling duplicate share credits.

### Description
- Removed the `if (!global.config.eth_pool_support) return callback(0, 1);` early return in `lib/pool/lifecycle.js` so worker IDs are always allocated/verified via the `pool_workers` table and per-process extranonce partitioning remains unique.

### Testing
- Ran `node --check lib/pool/lifecycle.js` and `node --check lib/pool.js`, and both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0bb553afdc83218a86edd3d9549b19)