### PR TITLE
Reject failed object block submit results

### DIFF
--- a/lib/coins/core/factories.js
+++ b/lib/coins/core/factories.js
@@ -1080,7 +1080,12 @@ function verifyErgShare(ctx) {
     return true;
 }
 
-function acceptDefinedResult(ctx) { return !!(ctx.rpcResult && typeof ctx.rpcResult.result !== "undefined"); }
+function acceptDefinedResult(ctx) {
+    if (!ctx.rpcResult || typeof ctx.rpcResult.result === "undefined") return false;
+    const result = ctx.rpcResult.result;
+    if (typeof result === "object" && result && typeof result.block_id === "undefined" && result.status !== "OK") return false;
+    return true;
+}
 
 function acceptBooleanTrue(ctx) { return !!(ctx.rpcResult && ctx.rpcResult.result === true); }
 

--- a/tests/pool/coin/submitters.js
+++ b/tests/pool/coin/submitters.js
@@ -136,6 +136,10 @@ test("dero block submit handlers preserve the pre-refactor payload and blid reso
         resolvedHash = hash;
     });
 
+    assert.equal(deroPool.acceptSubmittedBlock({ rpcResult: { result: { status: "FAILED", message: "rejected" } } }), false);
+    assert.equal(deroPool.acceptSubmittedBlock({ rpcResult: { result: { status: "OK" } } }), true);
+    assert.equal(deroPool.acceptSubmittedBlock({ rpcResult: { result: { block_id: "submitted-block" } } }), true);
+
     deroPool.submitBlockRpc.call(deroPool, {
         blockData: Buffer.from("bada55", "hex"),
         blockTemplate: {


### PR DESCRIPTION
### Motivation
- Fix a logic regression where non-main-coin RPC responses with any defined `result` (including rejection objects such as `{status: "FAILED"}`) were treated as successful block submissions and caused the pool to skip local slow-hash verification. 
- Prevent miners from exploiting that behavior to credit forged high-difficulty shares or cause undefined block hashes for some coin-specific paths.

### Description
- Tighten the default block-submit acceptance predicate in `lib/coins/core/factories.js` by changing `acceptDefinedResult` to return false for absent `rpcResult.result` and to reject result objects that lack a `block_id` and whose `status` is not `"OK"`.
- Add assertions to `tests/pool/coin/submitters.js` to cover rejection-shaped results and to verify `status: "OK"` and explicit `block_id` cases remain accepted.
- Commit message: `Reject failed object block submit results`.

### Testing
- Ran syntax checks with `node --check lib/coins/core/factories.js && node --check tests/pool/coin/submitters.js`, which succeeded. 
- Attempted the targeted test run with `npm test -- --test-name-pattern="dero block submit handlers|pool coin helpers: submitters"`, but it was blocked because `protocol-buffers` (a dependency required by the test harness) is not installed. 
- Attempted `npm install` to populate dependencies but it failed with a registry `403 Forbidden` for `crypto-js`, preventing full test execution in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0ba06b26888321b0b7f82ffa94099b)