### PR TITLE
Fix subnet connection counter rollback

### DIFF
--- a/lib/pool/servers.js
+++ b/lib/pool/servers.js
@@ -193,8 +193,13 @@ module.exports = function createServerFactory(deps) {
             socket.protocolErrorCount = 0;
             socket.finalizing = false;
 
-            if (incrementConnectionCount(state.activeConnectionsByIP, normalizedIp) > securityConfig.maxConnectionsPerIP ||
-                incrementConnectionCount(state.activeConnectionsBySubnet, subnet) > securityConfig.maxConnectionsPerSubnet) {
+            if (incrementConnectionCount(state.activeConnectionsByIP, normalizedIp) > securityConfig.maxConnectionsPerIP) {
+                decrementConnectionCount(state.activeConnectionsByIP, normalizedIp);
+                socket.destroyReason = "connection-limit";
+                socket.destroy();
+                return;
+            }
+            if (incrementConnectionCount(state.activeConnectionsBySubnet, subnet) > securityConfig.maxConnectionsPerSubnet) {
                 decrementConnectionCount(state.activeConnectionsByIP, normalizedIp);
                 decrementConnectionCount(state.activeConnectionsBySubnet, subnet);
                 socket.destroyReason = "connection-limit";

--- a/tests/pool/common/harness-runtime.js
+++ b/tests/pool/common/harness-runtime.js
@@ -167,9 +167,9 @@ class JsonLineClient {
     }
 }
 
-async function openRawSocket(port) {
+async function openRawSocket(port, options = {}) {
     return await new Promise((resolve, reject) => {
-        const socket = net.createConnection({ host: "127.0.0.1", port }, () => resolve(socket));
+        const socket = net.createConnection({ host: "127.0.0.1", port, ...options }, () => resolve(socket));
         socket.setEncoding("utf8");
         socket.once("error", reject);
     });

--- a/tests/pool/runtime/sockets.js
+++ b/tests/pool/runtime/sockets.js
@@ -320,6 +320,44 @@ test("per-subnet connection limits close excess sockets independently from the p
     }
 });
 
+
+test("rejected per-IP sockets do not reduce active subnet counts", async () => {
+    const { runtime } = await startHarness();
+    const originalMaxConnectionsPerIP = global.config.pool.maxConnectionsPerIP;
+    const originalMaxConnectionsPerSubnet = global.config.pool.maxConnectionsPerSubnet;
+    const first = await openRawSocket(MAIN_PORT, { localAddress: "127.0.0.10" });
+    const second = await openRawSocket(MAIN_PORT, { localAddress: "127.0.0.11" });
+    let rejectedByIp;
+    let secondRejectedByIp;
+    let rejectedBySubnet;
+
+    try {
+        global.config.pool.maxConnectionsPerIP = 1;
+        global.config.pool.maxConnectionsPerSubnet = 2;
+        rejectedByIp = await openRawSocket(MAIN_PORT, { localAddress: "127.0.0.10" });
+        await waitForSocketClose(rejectedByIp, 1000);
+
+        secondRejectedByIp = await openRawSocket(MAIN_PORT, { localAddress: "127.0.0.10" });
+        await waitForSocketClose(secondRejectedByIp, 1000);
+
+        assert.equal(runtime.getState().activeConnectionsBySubnet["127.0.0.0/24"], 2);
+
+        rejectedBySubnet = await openRawSocket(MAIN_PORT, { localAddress: "127.0.0.12" });
+        await waitForSocketClose(rejectedBySubnet, 1000);
+        await assertNoSocketData(first);
+        await assertNoSocketData(second);
+    } finally {
+        global.config.pool.maxConnectionsPerIP = originalMaxConnectionsPerIP;
+        global.config.pool.maxConnectionsPerSubnet = originalMaxConnectionsPerSubnet;
+        first.destroy();
+        second.destroy();
+        if (rejectedByIp) rejectedByIp.destroy();
+        if (secondRejectedByIp) secondRejectedByIp.destroy();
+        if (rejectedBySubnet) rejectedBySubnet.destroy();
+        await runtime.stop();
+    }
+});
+
 test("closing a miner socket removes it from the active miner map", async () => {
     const { runtime } = await startHarness();
     const client = new JsonLineClient(MAIN_PORT);


### PR DESCRIPTION
### Motivation
- Prevent subnet connection counters from being corrupted when sockets are rejected by the per-IP limit, which allows an attacker to bypass `maxConnectionsPerSubnet` by repeatedly opening rejected per-IP connections in the same /24.
- Ensure connection-accounting rollback only undoes counters that were actually incremented so subnet accounting remains accurate under rejection paths.

### Description
- Split the combined short-circuit check into two sequential checks in `lib/pool/servers.js` so a per-IP rejection only decrements the per-IP counter, and a per-subnet rejection decrements both counters; this avoids decrementing the subnet counter when it was never incremented.
- Updated the test helper `openRawSocket` in `tests/pool/common/harness-runtime.js` to accept an `options` parameter so tests can bind sockets to specific loopback source addresses via `localAddress`.
- Added a regression test `rejected per-IP sockets do not reduce active subnet counts` to `tests/pool/runtime/sockets.js` that exercises repeated per-IP rejections while the subnet is saturated and verifies the subnet count remains correct.

### Testing
- Ran syntax checks with `node --check lib/pool/servers.js && node --check tests/pool/common/harness-runtime.js && node --check tests/pool/runtime/sockets.js`, which completed successfully.
- Attempted to run the runtime test file with `node --require ./tests/common/test_output_buffer.js --test --test-reporter=./tests/common/spec_reporter.js --test-concurrency=1 tests/pool/runtime/sockets.js`, but execution failed due to a missing test-environment dependency (`protocol-buffers`), so the full test run could not be completed in this environment.
- The added test is present and marked to validate the regression once test dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0b94f6835883219fafbef22974c67a)