### PR TITLE
pool: reject duplicate shares for throttled trusted miners

### DIFF
--- a/lib/pool/protocol.js
+++ b/lib/pool/protocol.js
@@ -92,20 +92,18 @@ module.exports = function createProtocolHandler(deps) {
         return global.config.pool.minerThrottleShareWindow * global.config.pool.minerThrottleSharePerSec * multiplier;
     }
 
-    function willShareBeThrottled(miner) {
-        const minerWallet = state.minerWallets[miner.payout];
-        if (!minerWallet) return false;
-        const threshold = global.config.pool.minerThrottleSharePerSec * global.config.pool.minerThrottleShareWindow;
-        return minerWallet.last_ver_shares >= threshold;
-    }
-
     function trackJobSubmission(job, nonceTest) {
         const submissions = getJobSubmissions(job);
         submissions.set(nonceTest, 1);
     }
 
+    function untrackJobSubmission(job, nonceTest) {
+        getJobSubmissions(job).delete(nonceTest);
+    }
+
     function hasReachedSubmissionLimit(job, miner) {
-        return getJobSubmissions(job).size >= getTrackedSubmissionLimit(miner);
+        const limit = getTrackedSubmissionLimit(miner);
+        return limit > 0 && getJobSubmissions(job).size >= limit;
     }
 
     function getRateLimitConfig(method) {
@@ -703,7 +701,6 @@ module.exports = function createProtocolHandler(deps) {
         }
 
         function rejectDuplicateJobSubmission(miner, job, nonceTest) {
-            if (willShareBeThrottled(miner)) return false;
             const submissions = getJobSubmissions(job);
             if (submissions.has(nonceTest)) {
                 console.warn(state.threadName + formatPoolEvent("Duplicate share", { reason: "miner-nonce", nonce: nonceTest, miner: miner.logString }));
@@ -763,12 +760,12 @@ module.exports = function createProtocolHandler(deps) {
             if (!blockTemplate) return;
             const trackSharedTemplateNonceForShare = shouldTrackSharedTemplateNonce(job);
             if (rejectDuplicateTemplateNonce(miner, job, blockTemplate)) return;
-            const shareWindowThrottled = willShareBeThrottled(miner);
             if (rejectDuplicateJobSubmission(miner, job, nonceTest)) return;
             if (trackSharedTemplateNonceForShare) trackSharedTemplateNonce(blockTemplate, params.nonce);
-            if (!shareWindowThrottled) trackJobSubmission(job, nonceTest);
+            trackJobSubmission(job, nonceTest);
             job.rewarded_difficulty2 = job.rewarded_difficulty * job.coinHashFactor;
             shareProcessor.processShare(miner, job, blockTemplate, params, function onShareProcessed(shareAccepted) {
+                if (shareAccepted === null) untrackJobSubmission(job, nonceTest);
                 handleShareProcessed(miner, job, poolSettings, shareAccepted);
             });
         }

--- a/tests/pool/runtime/submissions.js
+++ b/tests/pool/runtime/submissions.js
@@ -107,6 +107,79 @@ test("throttled shares do not retain duplicate nonce entries", async () => {
     }
 });
 
+test("throttled trusted miners cannot replay a tracked nonce", async () => {
+    const validVector = RX0_MAIN_SHARE_VECTORS[0];
+    const { runtime } = await startHarness();
+    const originalThrottlePerSec = global.config.pool.minerThrottleSharePerSec;
+    const originalThrottleWindow = global.config.pool.minerThrottleShareWindow;
+    const originalTrustedMiners = global.config.pool.trustedMiners;
+    const originalRandomBytes = crypto.randomBytes;
+    const socket = {};
+
+    try {
+        global.config.pool.minerThrottleSharePerSec = 1;
+        global.config.pool.minerThrottleShareWindow = 1;
+        global.config.pool.trustedMiners = true;
+        crypto.randomBytes = () => Buffer.from([255]);
+
+        const loginReply = invokePoolMethod({
+            socket,
+            id: 1951,
+            method: "login",
+            params: {
+                login: MAIN_WALLET,
+                pass: "worker-throttled-trusted-replay"
+            }
+        });
+
+        const state = runtime.getState();
+        const miner = state.activeMiners.get(socket.miner_id);
+        const jobId = loginReply.replies[0].result.job.job_id;
+        const job = miner.validJobs.toarray().find((entry) => entry.id === jobId);
+        const threshold = global.config.pool.minerThrottleSharePerSec * global.config.pool.minerThrottleShareWindow;
+        state.walletTrust[MAIN_WALLET] = 1000;
+        state.minerWallets[MAIN_WALLET].last_ver_shares = threshold;
+        miner.trust.trust = 1000;
+        miner.trust.check_height = 0;
+
+        const firstReply = invokePoolMethod({
+            socket,
+            id: 1952,
+            method: "submit",
+            params: {
+                id: socket.miner_id,
+                job_id: jobId,
+                nonce: validVector.nonce,
+                result: validVector.expected
+            }
+        });
+
+        const replayReply = invokePoolMethod({
+            socket,
+            id: 1953,
+            method: "submit",
+            params: {
+                id: socket.miner_id,
+                job_id: jobId,
+                nonce: validVector.nonce,
+                result: validVector.expected
+            }
+        });
+
+        await flushTimers();
+        assert.deepEqual(firstReply.replies, [{ error: null, result: { status: "OK" } }]);
+        assert.deepEqual(replayReply.replies, [{ error: "Duplicate share", result: undefined }]);
+        assert.equal(job.submissions.has(validVector.nonce), true);
+        assert.equal(runtime.getState().shareStats.trustedShares, 1);
+    } finally {
+        global.config.pool.minerThrottleSharePerSec = originalThrottlePerSec;
+        global.config.pool.minerThrottleShareWindow = originalThrottleWindow;
+        global.config.pool.trustedMiners = originalTrustedMiners;
+        crypto.randomBytes = originalRandomBytes;
+        await runtime.stop();
+    }
+});
+
 test("expired shares do not retain unique nonce entries", async () => {
     const { runtime } = await startHarness();
     const socket = {};


### PR DESCRIPTION
### Motivation
- A recent change skipped per-job duplicate-nonce checks when a wallet was predicted to be throttled, which allowed trusted-share fast paths to bypass replay detection and credit duplicate work. 
- Trusted miners can reach the throttle threshold and then resubmit the same nonce via the trusted fast path, inflating credited shares and breaking accounting. 

### Description
- Stop short-circuiting duplicate/submission-cap checks: duplicate detection and submission-cap enforcement now run regardless of the wallet's throttle prediction by removing the `willShareBeThrottled` shortcut around job-level checks. 
- Always record the job nonce before calling `processShare`, and add `untrackJobSubmission(job, nonce)` to remove the tracked nonce if the share is actually throttled (`shareAccepted === null`). 
- Tighten `hasReachedSubmissionLimit` so a zero/disabled tracked limit does not cause accidental capping by returning `limit > 0 && ...`. 
- Add a regression test `tests/pool/runtime/submissions.js` that reproduces the issue and asserts a trusted miner at the throttle threshold cannot replay an already credited nonce. 

### Testing
- Performed static checks with `node --check lib/pool/protocol.js` and `node --check tests/pool/runtime/submissions.js`, which passed. 
- Attempted to run the test suite with `node --test tests/pool/runtime/submissions.js`, but execution was blocked by a missing dependency (`Cannot find module 'protocol-buffers'`). 
- Attempted `npm install` to resolve dependencies, but the install was blocked by a registry error (`403 Forbidden` for `crypto-js`) in this environment, so full automated test runs could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0b950b08a08321a0b75bc9dd5b6983)