### PR TITLE
Reject failed/locked/incoming wallet transfers when reconciling submitted batches

### DIFF
--- a/lib/payments/processor.js
+++ b/lib/payments/processor.js
@@ -431,6 +431,16 @@ module.exports = function createPaymentsProcessor(ctx, state, deps) {
         };
     }
 
+    function isReconcilableSubmittedTransfer(transfer) {
+        if (!transfer || typeof transfer !== "object") return false;
+        const transferType = typeof transfer.type === "string" ? transfer.type.toLowerCase() : "";
+        // Submitted batches may only finalize on durable outgoing entries.
+        // Reject failed, incoming, and still-locked history rows.
+        if (transferType !== "out") return false;
+        if (transfer.locked === true) return false;
+        return true;
+    }
+
     async function findSubmittedTransferVisibility(batch, items) {
         const txHash = normalizeHash(batch.tx_hash);
         const loadedTransfers = await loadWalletTransferByTxHash(txHash);
@@ -439,7 +449,9 @@ module.exports = function createPaymentsProcessor(ctx, state, deps) {
         // hash and the same destination set. That keeps a reused hash-shaped
         // field or malformed wallet row from finalizing the wrong batch.
         const visible = loadedTransfers.transfers.some(function hasExactSubmittedTransfer(transfer) {
-            return normalizeHash(transfer && transfer.txid) === txHash && transferMatchesBatch(batch, items, transfer);
+            return isReconcilableSubmittedTransfer(transfer) &&
+                normalizeHash(transfer && transfer.txid) === txHash &&
+                transferMatchesBatch(batch, items, transfer);
         });
         return visible ? { status: "visible" } : { status: "tx_not_found" };
     }

--- a/tests/payments/recovery_submitted.js
+++ b/tests/payments/recovery_submitted.js
@@ -140,6 +140,60 @@ test.describe("recovery submitted", { concurrency: false }, function recoverySub
         assert.equal(harness.wallet.calls.filter(function isTransfers(call) { return call.method === "get_transfers"; }).length, 0);
     });
 
+
+    test("submitted batches do not finalize when tx hash resolves only to a failed wallet transfer", async () => {
+        const grossAmount = Math.round(0.2 * COIN);
+        const feeAmount = Math.round(0.0001 * COIN);
+        const netAmount = grossAmount - feeAmount;
+        const txHash = "7".repeat(64);
+        const txKey = "8".repeat(64);
+        const harness = createHarness({
+            balances: [
+                { id: 1, payment_address: STANDARD_A, payment_id: null, pool_type: "pplns", amount: grossAmount, pending_batch_id: 1 }
+            ],
+            paymentBatches: [
+                createBatchRow({
+                    status: "submitted",
+                    submitted_at: "2026-04-17 11:10:05",
+                    tx_hash: txHash,
+                    tx_key: txKey,
+                    total_fee: 300000000,
+                    total_gross: grossAmount,
+                    total_net: netAmount
+                })
+            ],
+            paymentBatchItems: [
+                createBatchItemRow({ gross_amount: grossAmount, net_amount: netAmount, fee_amount: feeAmount })
+            ],
+            walletScript: {
+                get_transfer_by_txid: [function replyFailedTransfer() {
+                    return {
+                        result: {
+                            transfer: txTransferRecord(harness.clock, [{ address: STANDARD_A, amount: netAmount }], {
+                                txid: txHash,
+                                type: "failed",
+                                locked: true,
+                                fee: 300000000
+                            })
+                        }
+                    };
+                }]
+            }
+        });
+
+        const recovered = await harness.runtime.recoverPendingBatches("startup");
+
+        assert.equal(recovered, false);
+        assert.equal(harness.mysql.state.store.paymentBatches[0].status, "submitted");
+        assert.equal(harness.mysql.state.store.paymentBatches[0].reconcile_attempts, 1);
+        assert.equal(harness.mysql.state.store.paymentBatches[0].reconcile_clean_passes, 1);
+        assert.equal(harness.mysql.state.store.transactions.length, 0);
+        assert.equal(harness.mysql.state.store.payments.length, 0);
+        assert.equal(harness.mysql.state.store.balances[0].pending_batch_id, 1);
+        assert.match(harness.mysql.state.store.paymentBatches[0].last_error_text, /is not visible in wallet history yet/);
+        assert.equal(harness.wallet.calls.filter(function isTransfers(call) { return call.method === "get_transfer_by_txid"; }).length, 1);
+    });
+
     test("ambiguous submitting batches hold during recovery when wallet history is unavailable", async () => {
         const grossAmount = Math.round(0.2 * COIN);
         const feeAmount = Math.round(0.0001 * COIN);


### PR DESCRIPTION
### Motivation

- Prevent submitted payment batches from being considered visible/finalized when the wallet returns a transfer that is failed, incoming, or still locked, which could otherwise incorrectly finalize batches based on non-durable history rows.

### Description

- Add helper `isReconcilableSubmittedTransfer` to verify a wallet transfer is an outgoing, unlocked, durable record before reconciling.
- Update `findSubmittedTransferVisibility` to require `isReconcilableSubmittedTransfer(transfer)` in addition to matching `txid` and destination set.
- No other behavioral changes were made beyond filtering which wallet transfer rows count as visible for submitted batches.

### Testing

- Ran the `tests/payments/recovery_submitted.js` suite including the new test `submitted batches do not finalize when tx hash resolves only to a failed wallet transfer`, and assertions completed as expected.
- Existing recovery tests in the same file were executed and continued to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0b8c87850c83218b43ad7ae04ae864)