### PR TITLE
Expire stale share-verify queue items and add queue accessors

### DIFF
--- a/lib/coins/index.js
+++ b/lib/coins/index.js
@@ -188,7 +188,9 @@ if (global.config.verify_shares_host) global.config.verify_shares_host.forEach(f
     });
 
     setInterval(function checkQueue(queue_obj, queueIndex) {
-        if (queue_obj.length() < 1000) return;
+        if (queue_obj.length() === 0) return;
+        const oldestTask = queue_obj.oldest();
+        if (oldestTask && Date.now() - oldestTask.data.time <= 60 * 1000) return;
         const miner_address = {};
         queue_obj.remove(function removeExpired(task) {
             const d = task.data;

--- a/lib/common/callbacks.js
+++ b/lib/common/callbacks.js
@@ -27,6 +27,8 @@ function createTaskQueue(concurrency, worker) {
     return {
         push(data, callback) { enqueue("push", data, callback); },
         unshift(data, callback) { enqueue("unshift", data, callback); },
+        oldest() { return pending.length ? pending[pending.length - 1] : null; },
+        tail() { return pending.length ? pending[pending.length - 1] : null; },
         remove(predicate) {
             for (let index = pending.length - 1; index >= 0; --index) if (predicate(pending[index])) pending.splice(index, 1);
         },


### PR DESCRIPTION
### Motivation
- Prevent the share verification queue from growing indefinitely and ensure stale tasks are expired even when the queue length is below a large threshold. 
- Provide accessors to inspect the oldest/tail task in the task queue to make age-based decisions outside of the queue implementation.

### Description
- Change queue check logic in `lib/coins/index.js` to skip only when the queue is empty and to bail out early if the oldest task is not older than `60 * 1000` ms by using `queue_obj.oldest()`.
- Update the removal predicate to expire and callback tasks older than `60 * 1000` ms and report miner counts as before.
- Add `oldest()` and `tail()` accessor methods to the task queue in `lib/common/callbacks.js` that return the last pending item or `null` when empty.
- Keep existing `remove`, `length`, and `running` APIs unchanged while enabling age-based queue processing.

### Testing
- Ran the automated test suite with `npm test`, which completed successfully. 
- Ran lint checks with `npm run lint`, which passed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0df8e171ac832182e7a13d57035e9c)