### PR TITLE
Fix prototype-based wallet debug bypass in miner creation

### DIFF
--- a/lib/pool/miners.js
+++ b/lib/pool/miners.js
@@ -189,7 +189,7 @@ module.exports = function createMinerFactory(deps) {
         miner.paymentID = null;
         miner.identifier = agent && agent.includes("MinerGate") ? "MinerGate" : (rigid ? rigid : passSplit[0]).substring(0, 64);
 
-        miner.debugMiner = miner.payout in state.walletDebug;
+        miner.debugMiner = Object.prototype.hasOwnProperty.call(state.walletDebug, miner.payout);
         miner.whiteList = ipAddress in state.ipWhitelist;
         miner.email = passSplit.length >= 2 ? passSplit[1] : "";
         miner.logString = miner.payout.substr(miner.payout.length - 10) + ":" + miner.identifier + " (" + ipAddress + ")";


### PR DESCRIPTION
### Motivation
- Audit found two availability issues introduced by the wallet-debug feature: a strict-mode `ReferenceError` from an undeclared variable in the periodic loader and a prototype-property bypass that allows unauthenticated clients to enable verbose wallet-debug logging via names like `constructor`.
- The strict-mode crash path is not present in the current HEAD because list file loading is centralized (no code change proposed for that here), but the prototype-based bypass remained and needed a minimal fix to avoid enabling debug for inherited properties.

### Description
- Replace the `in` lookup against the wallet debug map with an own-property check by changing `miner.debugMiner = miner.payout in state.walletDebug;` to `miner.debugMiner = Object.prototype.hasOwnProperty.call(state.walletDebug, miner.payout);` in `lib/pool/miners.js`.
- This prevents inherited `Object.prototype` keys (for example `constructor`) from being treated as explicit wallet-debug entries while preserving intended behavior for explicit entries loaded from `wallet_debug.txt`.

### Testing
- Ran `node -e "require('./lib/pool/miners')"` and it completed successfully, indicating the module loads without syntax/runtime errors.
- Verified the intended file change was staged and committed with `git` (commit succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0bd36a0c608321aad5ad9cc667d4c5)