### PR TITLE
Retry async verifier when `slowHashAsync` returns unknown result

### DIFF
--- a/lib/pool/shares.js
+++ b/lib/pool/shares.js
@@ -103,6 +103,18 @@ module.exports = function createShareProcessor(deps) {
         walletLastSeeTime[miner.payout] = Date.now();
     }
 
+    function getVerifyRetryLimit() {
+        const verifyConfig = global.config.pool && global.config.pool.verifyShareRetry;
+        if (!verifyConfig || typeof verifyConfig.maxRetries !== "number") return 3;
+        return Math.max(0, Math.floor(verifyConfig.maxRetries));
+    }
+
+    function getVerifyRetryDelayMs() {
+        const verifyConfig = global.config.pool && global.config.pool.verifyShareRetry;
+        if (!verifyConfig || typeof verifyConfig.retryDelayMs !== "number") return 30;
+        return Math.max(0, Math.floor(verifyConfig.retryDelayMs));
+    }
+
     function storeShareDiv(miner, shareReward, shareReward2, shareNum, workerName, btPort, btHeight, btDifficulty, isBlockCandidate, isTrustedShare) {
         const timeNow = Date.now();
         if (miner.payout_div === null) {
@@ -462,18 +474,28 @@ module.exports = function createShareProcessor(deps) {
 
         function verifySlowShare(hashDiff, resultBuff, resultHash, blockData, convertedBlob, verifyShareCB) {
             const timeNow = Date.now();
-            global.coinFuncs.slowHashAsync(convertedBlob, blockTemplate, miner.payout, function (hash) {
-                if (hash === null) return processShareCB(null);
-                if (hash !== resultHash) {
-                    reportMinerShare(miner, job);
-                    return processShareCB(invalidShare(miner));
-                }
-                miner.lastSlowHashAsyncDelay = Date.now() - timeNow;
-                if (miner.lastSlowHashAsyncDelay > 1000) miner.lastSlowHashAsyncDelay = 1000;
-                ensureWalletTrustEntry(miner);
-                walletTrust[miner.payout] += job.rewarded_difficulty2;
-                return verifyShareCB(hashDiff, resultBuff, blockData, false, false);
-            });
+            const maxRetries = getVerifyRetryLimit();
+            const retryDelayMs = getVerifyRetryDelayMs();
+            let retries = 0;
+            const verifyOnce = function () {
+                global.coinFuncs.slowHashAsync(convertedBlob, blockTemplate, miner.payout, function (hash) {
+                    if (hash === null) return processShareCB(null);
+                    if (hash === false && retries < maxRetries) {
+                        retries += 1;
+                        return setTimeout(verifyOnce, retryDelayMs);
+                    }
+                    if (hash !== resultHash) {
+                        reportMinerShare(miner, job);
+                        return processShareCB(invalidShare(miner));
+                    }
+                    miner.lastSlowHashAsyncDelay = Date.now() - timeNow;
+                    if (miner.lastSlowHashAsyncDelay > 1000) miner.lastSlowHashAsyncDelay = 1000;
+                    ensureWalletTrustEntry(miner);
+                    walletTrust[miner.payout] += job.rewarded_difficulty2;
+                    return verifyShareCB(hashDiff, resultBuff, blockData, false, false);
+                });
+            };
+            verifyOnce();
         }
 
         const verifyShare = function (verifyShareCB) {

--- a/tests/pool/validation/core.js
+++ b/tests/pool/validation/core.js
@@ -9,6 +9,7 @@ const {
     VALID_RESULT,
     startHarness,
     invokePoolMethod,
+    flushTimers,
     poolModule
 } = require("../common/harness.js");
 
@@ -255,7 +256,9 @@ test("submit retries async verifier when verifier result is unknown", async () =
             params: { id: socket.miner_id, job_id: jobId, nonce: "0000000c", result: VALID_RESULT }
         });
 
-        await new Promise(resolve => setImmediate(resolve));
+        for (let i = 0; i < 10 && submitReply.replies.length === 0; ++i) {
+            await flushTimers();
+        }
         assert.deepEqual(submitReply.replies, [{ error: null, result: { status: "OK" } }]);
         assert.equal(slowHashCalls, 4);
         assert.equal(runtime.getState().shareStats.invalidShares, 0);

--- a/tests/pool/validation/core.js
+++ b/tests/pool/validation/core.js
@@ -225,6 +225,48 @@ test("submit accepts shares when the verifier returns the hash in reverse byte o
     }
 });
 
+test("submit retries async verifier when verifier result is unknown", async () => {
+    const { runtime, database } = await startHarness();
+    const socket = {};
+    const originalSlowHashAsync = global.coinFuncs.slowHashAsync;
+    const originalVerifyRetryConfig = global.config.pool.verifyShareRetry;
+    let slowHashCalls = 0;
+
+    try {
+        global.config.pool.verifyShareRetry = { maxRetries: 3, retryDelayMs: 0 };
+        global.coinFuncs.slowHashAsync = function unknownThenValidHash(_buffer, _blockTemplate, _wallet, callback) {
+            slowHashCalls += 1;
+            if (slowHashCalls < 4) return callback(false);
+            callback(VALID_RESULT);
+        };
+
+        const loginReply = invokePoolMethod({
+            socket,
+            id: 134,
+            method: "login",
+            params: { login: MAIN_WALLET, pass: "worker-remote-retry" }
+        });
+        const jobId = loginReply.replies[0].result.job.job_id;
+
+        const submitReply = invokePoolMethod({
+            socket,
+            id: 135,
+            method: "submit",
+            params: { id: socket.miner_id, job_id: jobId, nonce: "0000000c", result: VALID_RESULT }
+        });
+
+        await new Promise(resolve => setImmediate(resolve));
+        assert.deepEqual(submitReply.replies, [{ error: null, result: { status: "OK" } }]);
+        assert.equal(slowHashCalls, 4);
+        assert.equal(runtime.getState().shareStats.invalidShares, 0);
+        assert.equal(database.invalidShares.length, 0);
+    } finally {
+        global.config.pool.verifyShareRetry = originalVerifyRetryConfig;
+        global.coinFuncs.slowHashAsync = originalSlowHashAsync;
+        await runtime.stop();
+    }
+});
+
 test("wallet bans propagated through messageHandler reject later logins", async () => {
     const { runtime } = await startHarness();
     const cluster = require("cluster");


### PR DESCRIPTION
### Motivation

- Some verifier implementations return an unknown/temporary result (e.g. `false`) which should trigger a retry instead of immediately failing verification.

### Description

- Add retry logic for asynchronous share verification in `verifySlowShare` that retries when `global.coinFuncs.slowHashAsync` calls back with `false`, using configurable limits and delays via `global.config.pool.verifyShareRetry`.
- Introduce helper getters `getVerifyRetryLimit()` and `getVerifyRetryDelayMs()` with safe defaults of `3` retries and `30` ms delay and robust parsing of the config values.
- Preserve original behavior for `null` results and mismatched hashes while capping computed delays and retries to sane integer values.
- Add a unit test `submit retries async verifier when verifier result is unknown` in `tests/pool/validation/core.js` that simulates `slowHashAsync` returning `false` a few times before returning a valid result and asserts the retry behavior.

### Testing

- Ran the pool validation tests in `tests/pool/validation/core.js` including the new retry test which asserts `slowHashAsync` was invoked the expected number of times and that the submission succeeded; the tests passed.
- Existing async verification behavior for `null` results and hash mismatches was exercised by the same test suite and remained unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0e03b1258c8321b48ea3d28dbd9313)