### PR TITLE
Enforce `workerMax` for proxy miners (remove spoofable `xmrig_proxy` exemption)

### DIFF
--- a/lib/pool/miner_registry.js
+++ b/lib/pool/miner_registry.js
@@ -100,7 +100,7 @@ module.exports = function createMinerRegistry(deps) {
         if (!(proxyMinerName in state.proxyMiners)) {
             state.proxyMiners[proxyMinerName] = { connectTime: Date.now(), count: 1, hashes: 0 };
             console.log(state.threadName + formatPoolEvent("Proxy track", { payout: proxyMinerName }));
-        } else if (++state.proxyMiners[proxyMinerName].count > global.config.pool.workerMax && !miner.xmrig_proxy) {
+        } else if (++state.proxyMiners[proxyMinerName].count > global.config.pool.workerMax) {
             console.error(state.threadName + formatPoolEvent("Wallet long ban", {
                 payout: wallet,
                 reason: "worker-limit"


### PR DESCRIPTION
### Motivation
- The public Stratum `agent` string was being used to set `miner.xmrig_proxy`, which allowed unauthenticated clients to spoof `xmrig-proxy` and bypass the configured wallet-level worker cap; the reported `worker.js` syntax issue was validated not present in current `HEAD`.

### Description
- Remove the `xmrig_proxy` exemption in `addProxyMiner` so the `pool.workerMax` check is applied unconditionally in `lib/pool/miner_registry.js`, preserving existing proxy tracking behavior.

### Testing
- Ran `node --check` on `lib/pool/miner_registry.js`, `lib/pool/miners.js`, `lib/pool/protocol.js`, and `lib/worker.js`, and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0bb6350df08321b1e3fb4e8e3737ef)