### PR TITLE
Prevent disconnected miners from bypassing invalid-share ban

### DIFF
--- a/lib/pool/protocol.js
+++ b/lib/pool/protocol.js
@@ -717,12 +717,13 @@ module.exports = function createProtocolHandler(deps) {
         }
 
         function handleShareProcessed(miner, job, poolSettings, shareAccepted) {
+            let banned = false;
+            if (shareAccepted !== null) banned = miner.checkBan(shareAccepted);
             if (miner.removed_miner) return;
             if (shareAccepted === null) {
                 sendReply("Throttled down share submission (please increase difficulty)");
                 return;
             }
-            const banned = miner.checkBan(shareAccepted);
             if (global.config.pool.trustedMiners) {
                 if (shareAccepted) {
                     miner.trust.trust += job.rewarded_difficulty2;


### PR DESCRIPTION
### Motivation
- The socket-close path began marking miners as removed which caused asynchronous share-validation callbacks to return before calling `miner.checkBan`, allowing remote miners to disconnect after submitting invalid shares and avoid temporary bans while still consuming verification/daemon resources.

### Description
- Invoke `miner.checkBan(shareAccepted)` before the `miner.removed_miner` early-return in `handleShareProcessed` inside `lib/pool/protocol.js` so ban/accounting runs even for shares validated after a disconnect, while preserving throttled reply behavior and existing socket reply flow.

### Testing
- Ran `npm test --silent` in this environment but the test run failed due to a missing dependency (`protocol-buffers`), so the full automated test suite could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0bb7d2f82083218abc7b72c7885d67)