### PR TITLE
Fix stale-template timeout assignment during block template rotation

### DIFF
--- a/lib/pool/templates.js
+++ b/lib/pool/templates.js
@@ -349,9 +349,8 @@ module.exports = function createTemplateManager(deps) {
         if (previousTemplate && previousTemplate.idHash === template.idHash) return;
         let isExtraCheck = false;
         if (previousTemplate) {
-            if (coin in pastBlockTemplates) {
-                pastBlockTemplates[coin].get(0).timeoutTime = Date.now() + 4 * 1000;
-            } else {
+            previousTemplate.timeoutTime = Date.now() + 4 * 1000;
+            if (!(coin in pastBlockTemplates)) {
                 pastBlockTemplates[coin] = global.support.circularBuffer(10);
             }
             pastBlockTemplates[coin].enq(previousTemplate);


### PR DESCRIPTION
### Motivation
- The pool must penalize miners who continue mining a previous block more than 4 seconds after it is replaced by stamping the outgoing active template with a `timeoutTime` so submit-path decay/rejection logic can run. 
- A prior change accidentally assigned `timeoutTime` to `pastBlockTemplates[coin].get(0)` (an already-past entry) instead of the template being retired, allowing the just-replaced template to be enqueued without `timeoutTime` and bypass stale-share handling. 

### Description
- Assign `timeoutTime` on the outgoing template itself via `previousTemplate.timeoutTime = Date.now() + 4 * 1000` before enqueueing it into `pastBlockTemplates`. 
- Preserve existing circular buffer initialization by creating `pastBlockTemplates[coin]` when missing and then calling `pastBlockTemplates[coin].enq(previousTemplate)`. 
- This change is implemented in `lib/pool/templates.js` and restores the intended 4-second grace window for the just-staled template so submit logic that checks `blockTemplate.timeoutTime` will trigger correctly. 

### Testing
- Ran the project test runner with `npm -s test`, which could not complete in this environment due to a missing dependency (`protocol-buffers`), so the full automated test-suite did not run successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0e1fd788a48321af7eb723bc040e73)