### PR TITLE
Simplify submit-port resolution and add explicit main/dual submit ports

### DIFF
--- a/deployment/base.sql
+++ b/deployment/base.sql
@@ -244,6 +244,8 @@ INSERT INTO pool.config (module, item, item_value, item_type, Item_desc) VALUES 
 INSERT INTO pool.config (module, item, item_value, item_type, Item_desc) VALUES ('pool', 'retargetTime', '60', 'int', 'Time between difficulty retargets');
 INSERT INTO pool.config (module, item, item_value, item_type, Item_desc) VALUES ('daemon', 'address', '127.0.0.1', 'string', 'Monero Daemon RPC IP');
 INSERT INTO pool.config (module, item, item_value, item_type, Item_desc) VALUES ('daemon', 'port', '18081', 'int', 'Monero Daemon RPC Port');
+INSERT INTO pool.config (module, item, item_value, item_type, Item_desc) VALUES ('daemon', 'mainBlockSubmitPort', '18083', 'int', 'Explicit daemon port used for authoritative main-chain block submissions.');
+INSERT INTO pool.config (module, item, item_value, item_type, Item_desc) VALUES ('daemon', 'dualBlockSubmitPort', '18081', 'int', 'Explicit daemon port used for auxiliary dual-chain block submissions.');
 INSERT INTO pool.config (module, item, item_value, item_type, Item_desc) VALUES ('daemon', 'basicAuth', '', 'string', 'Basic auth header if needed by daemon');
 INSERT INTO pool.config (module, item, item_value, item_type, Item_desc) VALUES ('daemon', 'X-API-KEY', '', 'string', 'Turtle wallet API auth header');
 INSERT INTO pool.config (module, item, item_value, item_type, Item_desc) VALUES ('daemon', 'pollInterval', '100', 'int', 'Time in ms between pool daemon checks for new blocks');

--- a/lib/coins/core/factories.js
+++ b/lib/coins/core/factories.js
@@ -1202,17 +1202,17 @@ function submitXtmCBlock(ctx) {
 function submitDualMainBlock(ctx) {
     const isXmr = parseInt(ctx.hashDiff, 10) >= ctx.blockTemplate.xmr_difficulty;
     const isXtm = parseInt(ctx.hashDiff, 10) >= ctx.blockTemplate.xtm_difficulty;
-    const mainSubmitPort = ctx.blockTemplate.port + (this.mainSubmitPortOffset || 0);
-    const auxSubmitPort = ctx.blockTemplate.port + (this.dualSubmitPortOffset || 0);
+    const mainSubmitPort = Number(global.config.daemon.mainBlockSubmitPort || this.mainSubmitPort || ctx.blockTemplate.port);
+    const auxSubmitPort = Number(global.config.daemon.dualBlockSubmitPort || this.dualSubmitPort || ctx.blockTemplate.port);
 
     if (isXmr && (!ctx.portUsedToSubmit || ctx.portUsedToSubmit === mainSubmitPort)) {
         ctx.support.rpcPortDaemon(mainSubmitPort, "submitblock", [ctx.blockData.toString("hex")], function onMainSubmit(rpcResult, rpcStatus) {
-            return ctx.replyDispatcher(rpcResult, rpcStatus, mainSubmitPort, ctx.submitBlockCB);
+            return ctx.replyDispatcher(rpcResult, rpcStatus, mainSubmitPort, ctx.submitBlockCB, false);
         }, true);
     }
     if (isXtm && (!ctx.portUsedToSubmit || ctx.portUsedToSubmit === auxSubmitPort)) {
         ctx.support.rpcPortDaemon(auxSubmitPort, "submitblock", [ctx.blockData.toString("hex")], function onAuxSubmit(rpcResult, rpcStatus) {
-            return ctx.replyDispatcher(rpcResult, rpcStatus, auxSubmitPort, isXmr ? null : ctx.submitBlockCB);
+            return ctx.replyDispatcher(rpcResult, rpcStatus, auxSubmitPort, isXmr ? null : ctx.submitBlockCB, true);
         }, true);
     }
     if (!isXmr && !isXtm) {
@@ -1220,10 +1220,10 @@ function submitDualMainBlock(ctx) {
             global.support.sendAdminFyi("coins:low-diff-submit:" + ctx.blockTemplate.port, "FYI: Can't submit low diff block to deamon on " + ctx.blockTemplate.port + " port", "The pool server: " + global.config.hostname + " can't submit low diff block to deamon on " + ctx.blockTemplate.port + " port");
         }
         ctx.support.rpcPortDaemon(mainSubmitPort, "submitblock", [ctx.blockData.toString("hex")], function onLowMainSubmit(rpcResult, rpcStatus) {
-            return ctx.replyDispatcher(rpcResult, rpcStatus, mainSubmitPort, ctx.submitBlockCB);
+            return ctx.replyDispatcher(rpcResult, rpcStatus, mainSubmitPort, ctx.submitBlockCB, false);
         }, true);
         ctx.support.rpcPortDaemon(auxSubmitPort, "submitblock", [ctx.blockData.toString("hex")], function onLowAuxSubmit(rpcResult, rpcStatus) {
-            return ctx.replyDispatcher(rpcResult, rpcStatus, auxSubmitPort, null);
+            return ctx.replyDispatcher(rpcResult, rpcStatus, auxSubmitPort, null, true);
         }, true);
     }
 }

--- a/lib/coins/xmr.js
+++ b/lib/coins/xmr.js
@@ -13,8 +13,8 @@ module.exports = createProfile({
         acceptSubmittedBlock: pool.submitAccept.statusOkObject,
         dualSubmitDisplayCoin: "XTM",
         dualSubmitReportPort: 18144,
-        dualSubmitPortOffset: 0,
-        mainSubmitPortOffset: 2,
+        dualSubmitPort: 18081,
+        mainSubmitPort: 18083,
         submitBlockRpc: pool.blockSubmit.dualMain
     }),
     network: {

--- a/lib/pool/share_blocks.js
+++ b/lib/pool/share_blocks.js
@@ -189,8 +189,10 @@ module.exports = function createShareBlockHelpers(deps) {
             }, 2 * 1000);
         }
 
-        function buildSubmitReport(port) {
-            const isDisplaySubmitPort = port === global.config.daemon.port && !!dualDisplayCoin;
+        function buildSubmitReport(port, isDisplaySubmitPortOverride) {
+            const isDisplaySubmitPort = typeof isDisplaySubmitPortOverride === "boolean"
+                ? isDisplaySubmitPortOverride
+                : port === global.config.daemon.port && !!dualDisplayCoin;
             const reportCoin = isDisplaySubmitPort ? dualDisplayCoin : blockTemplate.coin;
             const reportDiff = isDisplaySubmitPort ? blockTemplate.xtm_difficulty : blockTemplate.difficulty;
             const reportPort = isDisplaySubmitPort ? dualDisplayPort : blockTemplate.port;
@@ -199,8 +201,8 @@ module.exports = function createShareBlockHelpers(deps) {
             return { activeHeight, isDisplaySubmitPort, reportCoinPort: formatCoinPort(reportCoin, reportPort), reportDiff, reportHeight, reportPort };
         }
 
-        const replyFn = function (rpcResult, rpcStatus, port, nextSubmitBlockCB) {
-            const { activeHeight, isDisplaySubmitPort, reportCoinPort, reportDiff, reportHeight, reportPort } = buildSubmitReport(port);
+        const replyFn = function (rpcResult, rpcStatus, port, nextSubmitBlockCB, isDisplaySubmitPortOverride) {
+            const { activeHeight, isDisplaySubmitPort, reportCoinPort, reportDiff, reportHeight, reportPort } = buildSubmitReport(port, isDisplaySubmitPortOverride);
             const requiredBlockDiff = isMainPort && !isDisplaySubmitPort && blockTemplate.xmr_difficulty ? blockTemplate.xmr_difficulty : reportDiff;
             const getDiffMessage = function () {
                 return getBlockSubmitDiffMessage(blockTemplate, blockData, resultBuff, hashDiff, requiredBlockDiff, job);

--- a/tests/pool/common/harness-core.js
+++ b/tests/pool/common/harness-core.js
@@ -53,6 +53,8 @@ function allocateTestPorts() {
 }
 
 const [MAIN_PORT, ETH_PORT] = allocateTestPorts();
+const MAIN_SUBMIT_PORT = MAIN_PORT + 2;
+const DUAL_SUBMIT_PORT = MAIN_PORT;
 const MAIN_WALLET = "4".repeat(95);
 const ETH_WALLET = "5".repeat(95);
 const ALT_WALLET = "6".repeat(95);
@@ -502,6 +504,8 @@ function createBaseTemplate({ coin, port, idHash, height }) {
 
 module.exports = {
     MAIN_PORT,
+    MAIN_SUBMIT_PORT,
+    DUAL_SUBMIT_PORT,
     ETH_PORT,
     MAIN_WALLET,
     ETH_WALLET,

--- a/tests/pool/common/harness-core.js
+++ b/tests/pool/common/harness-core.js
@@ -53,8 +53,8 @@ function allocateTestPorts() {
 }
 
 const [MAIN_PORT, ETH_PORT] = allocateTestPorts();
-const MAIN_SUBMIT_PORT = MAIN_PORT + 2;
-const DUAL_SUBMIT_PORT = MAIN_PORT;
+const MAIN_SUBMIT_PORT = 18083;
+const DUAL_SUBMIT_PORT = 18081;
 const MAIN_WALLET = "4".repeat(95);
 const ETH_WALLET = "5".repeat(95);
 const ALT_WALLET = "6".repeat(95);

--- a/tests/pool/common/runtime-helpers.js
+++ b/tests/pool/common/runtime-helpers.js
@@ -7,6 +7,8 @@ const test = require("node:test");
 
 const {
     MAIN_PORT,
+    MAIN_SUBMIT_PORT,
+    DUAL_SUBMIT_PORT,
     ETH_PORT,
     MAIN_WALLET,
     ALT_WALLET,
@@ -274,6 +276,8 @@ module.exports = {
     fs,
     fsp,
     MAIN_PORT,
+    MAIN_SUBMIT_PORT,
+    DUAL_SUBMIT_PORT,
     ETH_PORT,
     MAIN_WALLET,
     ALT_WALLET,

--- a/tests/pool/runtime/daemons.js
+++ b/tests/pool/runtime/daemons.js
@@ -7,6 +7,8 @@ const {
     fs,
     fsp,
     MAIN_PORT,
+    MAIN_SUBMIT_PORT,
+    DUAL_SUBMIT_PORT,
     ETH_PORT,
     MAIN_WALLET,
     ALT_WALLET,
@@ -501,7 +503,7 @@ test("wallet trust enables daemon-first block submit for a new same-wallet sessi
         await flushTimers();
         assert.deepEqual(candidateSubmitReply.replies, [{ error: null, result: { status: "OK" } }]);
         assert.equal(global.support.rpcPortDaemonCalls.length, 1);
-        assert.equal(global.support.rpcPortDaemonCalls[0].port, MAIN_PORT + 2);
+        assert.equal(global.support.rpcPortDaemonCalls[0].port, MAIN_SUBMIT_PORT);
     } finally {
         await runtime.stop();
     }
@@ -614,7 +616,7 @@ test("main-chain candidates that only satisfy the XMR threshold submit only to t
 
         await flushTimers();
         assert.deepEqual(submitReply.replies, [{ error: null, result: { status: "OK" } }]);
-        assert.deepEqual(global.support.rpcPortDaemonCalls.map((entry) => entry.port), [MAIN_PORT + 2]);
+        assert.deepEqual(global.support.rpcPortDaemonCalls.map((entry) => entry.port), [MAIN_SUBMIT_PORT]);
         assert.equal(database.blocks.length, 1);
         assert.equal(database.altBlocks.length, 0);
     } finally {
@@ -665,7 +667,7 @@ test("main-chain candidates that satisfy both thresholds submit to both XMR and 
 
         await flushTimers();
         assert.deepEqual(submitReply.replies, [{ error: null, result: { status: "OK" } }]);
-        assert.deepEqual(global.support.rpcPortDaemonCalls.map((entry) => entry.port), [MAIN_PORT + 2, MAIN_PORT]);
+        assert.deepEqual(global.support.rpcPortDaemonCalls.map((entry) => entry.port), [MAIN_SUBMIT_PORT, DUAL_SUBMIT_PORT]);
         assert.equal(database.blocks.length, 1);
         assert.equal(database.altBlocks.length, 1);
         assert.equal(database.altBlocks[0].payload.port, 18144);
@@ -718,7 +720,7 @@ test("low-diff main-port block candidates still submit to both daemons and notif
 
         await flushTimers();
         assert.deepEqual(submitReply.replies, [{ error: null, result: { status: "OK" } }]);
-        assert.deepEqual(global.support.rpcPortDaemonCalls.map((entry) => entry.port), [MAIN_PORT + 2, MAIN_PORT]);
+        assert.deepEqual(global.support.rpcPortDaemonCalls.map((entry) => entry.port), [MAIN_SUBMIT_PORT, DUAL_SUBMIT_PORT]);
         assert.equal(global.support.emails.some((entry) => entry.subject.includes("low diff block")), true);
         assert.equal(database.blocks.length, 1);
         assert.equal(database.altBlocks.length, 1);


### PR DESCRIPTION
### Motivation
- Avoid implicit +2 offset assumptions and brittle port-role inference that caused main-chain submits to be misclassified and skipped from authoritative storage. 
- Use explicit submit port configuration so deployments that put XMR RPC on a different port (e.g. +2 behind a Tari proxy) are intentional and visible. 
- Make test expectations canonical by centralizing submit-port constants next to `MAIN_PORT` to reduce duplication and confusion.

### Description
- Replace the `resolveBlockSubmitPort` helper with a simpler inline fallback that resolves submit ports as `global.config.daemon.mainBlockSubmitPort || this.mainSubmitPort || templatePort` and the equivalent for the dual port in `lib/coins/core/factories.js`.
- Add explicit DB config defaults `mainBlockSubmitPort = 18083` and `dualBlockSubmitPort = 18081` to `deployment/base.sql` so the +2 submission topology is encoded in configuration.
- Update the XMR profile in `lib/coins/xmr.js` to expose `mainSubmitPort: 18083` and `dualSubmitPort: 18081` as profile-level defaults.
- Centralize test constants by adding `MAIN_SUBMIT_PORT` and `DUAL_SUBMIT_PORT` alongside `MAIN_PORT` in `tests/pool/common/harness-core.js`, re-exporting them in `tests/pool/common/runtime-helpers.js`, and updating `tests/pool/runtime/daemons.js` to use the shared constants.
- Preserve the earlier fix that makes submit reply handling explicit (pass an `isDisplaySubmitPort` override into the reply/dispatch flow) so accounting no longer infers chain role from `daemon.port` equality.

### Testing
- Confirmed code references: searched for removed helper and new config/constant names and found the updated call sites (`rg` checks for `resolveBlockSubmitPort`, `mainBlockSubmitPort`, `MAIN_SUBMIT_PORT`, etc.).
- Updated runtime test assertions in `tests/pool/runtime/daemons.js` to assert against `MAIN_SUBMIT_PORT`/`DUAL_SUBMIT_PORT` behavior.
- Attempted to run the daemon runtime tests (`tests/pool/runtime/daemons.js`) but the local environment is missing the `protocol-buffers` module so the test run failed to start with `MODULE_NOT_FOUND`; grep/validation checks passed and test changes are in place.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0e2596644c832187e4b94c55a5c0fd)