### PR TITLE
Filter BTC-style sum-vout rewards to pool address for RVN/RTM/BTRM/XNA

### DIFF
--- a/lib/coins/btrm.js
+++ b/lib/coins/btrm.js
@@ -5,6 +5,8 @@ module.exports = preset.btcSubmitReserve({ port: 10225, coin: "BTRM", blobType: 
     blob: blob.rtm(),
     rpc: rpc.btc({
         createBlockTemplate: btcTemplate.rtm,
+        headerRewardMode: "sum-vout",
+        rewardPoolAddressOnly: true,
         rewardMultiplier: 100000000,
         difficultyMultiplier: 0xFFFFFFFF
     }),

--- a/lib/coins/core/factories.js
+++ b/lib/coins/core/factories.js
@@ -45,11 +45,20 @@ function createProfile(spec) {
 
 function isCoinProfile(value) { return !!(value && value[COIN_PROFILE_SYMBOL] === true); }
 
-function parseBtcReward(block, config) {
+function getBtcVoutAddresses(vout) {
+    if (!vout || !vout.scriptPubKey) return [];
+    if (Array.isArray(vout.scriptPubKey.addresses)) return vout.scriptPubKey.addresses;
+    if (typeof vout.scriptPubKey.address === "string") return [vout.scriptPubKey.address];
+    return [];
+}
+
+function parseBtcReward(block, config, poolAddress) {
     block.reward = 0;
     for (const vout of block.tx[0].vout) {
+        const addresses = getBtcVoutAddresses(vout);
         if (config.headerRewardMode === "sum-vout") {
-            if (config.rewardIgnoreAddress && vout.scriptPubKey.addresses && vout.scriptPubKey.addresses[0] === config.rewardIgnoreAddress) continue;
+            if (config.rewardPoolAddressOnly && !addresses.includes(poolAddress)) continue;
+            if (config.rewardIgnoreAddress && addresses.includes(config.rewardIgnoreAddress)) continue;
             block.reward += vout.value;
         } else if (vout.value > block.reward) {
             block.reward = vout.value;
@@ -229,7 +238,7 @@ function createBtcRpc(overrides) {
     config.getAnyBlockHeaderByHash = function getAnyBlockHeaderByHash(ctx) {
         ctx.runtime.support.rpcPortDaemon2(ctx.port, "", { method: "getblock", params: [ctx.blockHash, 2] }, function onBlock(body) {
             if (!body || !body.result || !(body.result.tx instanceof Array) || body.result.tx.length < 1) return ctx.callback(true, body);
-            return ctx.callback(null, parseBtcReward(body.result, config));
+            return ctx.callback(null, parseBtcReward(body.result, config, ctx.runtime.getPoolAddress(ctx.profile)));
         }, ctx.noErrorReport);
     };
 

--- a/lib/coins/rtm.js
+++ b/lib/coins/rtm.js
@@ -5,6 +5,8 @@ module.exports = preset.btcSubmitReserve({ port: 9998, coin: "RTM", blobType: 10
     blob: blob.rtm(),
     rpc: rpc.btc({
         createBlockTemplate: btcTemplate.rtm,
+        headerRewardMode: "sum-vout",
+        rewardPoolAddressOnly: true,
         rewardMultiplier: 100000000,
         difficultyMultiplier: 0xFFFFFFFF
     }),

--- a/lib/coins/rvn.js
+++ b/lib/coins/rvn.js
@@ -8,6 +8,7 @@ module.exports = preset.directReserve({ port: 8766, coin: "RVN", blobType: 101, 
     rpc: rpc.btc({
         createBlockTemplate: btcTemplate.raven,
         headerRewardMode: "sum-vout",
+        rewardPoolAddressOnly: true,
         rewardMultiplier: 100000000
     }),
     pow: pow.kawpow()

--- a/lib/coins/xna.js
+++ b/lib/coins/xna.js
@@ -8,6 +8,7 @@ module.exports = preset.directReserve({ port: 19001, coin: "XNA", blobType: 101,
     rpc: rpc.btc({
         createBlockTemplate: btcTemplate.raven,
         headerRewardMode: "sum-vout",
+        rewardPoolAddressOnly: true,
         rewardMultiplier: 100000000
     }),
     pow: pow.kawpow(),

--- a/tests/pool/coin/basics.js
+++ b/tests/pool/coin/basics.js
@@ -333,6 +333,55 @@ test("wallet reward selectors stay on the coin profiles for asset-aware chains",
     }), 7);
 });
 
+
+test("raven-style reward accounting only credits coinbase outputs paid to the pool address", async () => {
+    const coinFuncs = global.coinFuncs.__realCoinFuncs;
+    const rvnRpc = coinFuncs.getRpcSettings("RVN");
+    const poolAddress = "RPoolRewardAddress111111111111111111";
+    const thirdPartyAddress = "RThirdPartyAddress1111111111111111";
+    let callbackArgs = null;
+
+    await new Promise((resolve) => {
+        rvnRpc.getAnyBlockHeaderByHash({
+            blockHash: "aa".repeat(32),
+            callback(err, body) {
+                callbackArgs = { err, body };
+                resolve();
+            },
+            isOurBlock: true,
+            noErrorReport: true,
+            port: 8766,
+            profile: coinFuncs.getPoolProfile("RVN"),
+            runtime: {
+                getPoolAddress() { return poolAddress; },
+                support: {
+                    rpcPortDaemon2(_port, _method, params, callback) {
+                        assert.deepEqual(params, { method: "getblock", params: ["aa".repeat(32), 2] });
+                        callback({
+                            result: {
+                                hash: "aa".repeat(32),
+                                height: 123,
+                                difficulty: 456,
+                                tx: [{
+                                    vout: [
+                                        { value: 50, scriptPubKey: { addresses: [poolAddress] } },
+                                        { value: 12.5, scriptPubKey: { addresses: [thirdPartyAddress] } },
+                                        { value: 25, scriptPubKey: { address: poolAddress } },
+                                        { value: 1, scriptPubKey: { addresses: [] } }
+                                    ]
+                                }]
+                            }
+                        });
+                    }
+                }
+            }
+        });
+    });
+
+    assert.equal(callbackArgs.err, null);
+    assert.equal(callbackArgs.body.reward, 7500000000);
+});
+
 test("eth-style hash lookups preserve hex block heights when deriving canonical headers", async () => {
     const coinFuncs = global.coinFuncs.__realCoinFuncs;
     const etcRpc = coinFuncs.getRpcSettings("ETC");


### PR DESCRIPTION
### Motivation
- BTC-style `sum-vout` reward accounting for some Raven-like ports was summing every coinbase output value as the block reward, which inflates the pool-creditable reward when coinbase enforces mandatory third-party outputs (masternodes/treasury/dev-fund). 
- The intended behavior for pool-backed ports is to only count outputs payable to the pool wallet (or ignore configured addresses), so miners are not over-credited from pool reserves.

### Description
- Added `getBtcVoutAddresses(vout)` helper and updated `parseBtcReward` to accept a `poolAddress` argument and to respect a new `rewardPoolAddressOnly` flag so that `sum-vout` mode can skip outputs not paid to the configured pool address and still honor `rewardIgnoreAddress` when present (`lib/coins/core/factories.js`).
- Changed `createBtcRpc` to pass `ctx.runtime.getPoolAddress(ctx.profile)` into `parseBtcReward` when resolving block headers so reward calculation can be pool-address aware (`lib/coins/core/factories.js`).
- Enabled `rewardPoolAddressOnly: true` for the affected profiles `RVN`, `XNA`, `RTM`, and `BTRM` so those ports use pool-address-only summation (`lib/coins/rvn.js`, `lib/coins/xna.js`, `lib/coins/rtm.js`, `lib/coins/btrm.js`).
- Added a regression test that asserts third-party coinbase outputs are ignored while multiple pool-address outputs are summed into the reported reward (`tests/pool/coin/basics.js`).

### Testing
- Performed static syntax checks with `node --check` across the changed modules which completed successfully. 
- Executed a targeted Node.js snippet exercising the new reward accounting path which validated the corrected reward (succeeded). 
- Ran the package test harness invocation `node --require ./tests/common/test_output_buffer.js --test ... tests/pool/coin/basics.js` but it failed to run due to missing test dependencies (`protocol-buffers` module not installed) and therefore the full test suite was not executed. 
- Attempted `npm install` to provision test deps but it failed due to registry access returning `403 Forbidden` for `crypto-js`, preventing full automated test execution in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0ba5fd7ae483218963e1e1a783af77)