### PR TITLE
Validate RTM/BTRM coinbase reward destinations

### DIFF
--- a/lib/coins/btrm.js
+++ b/lib/coins/btrm.js
@@ -6,6 +6,7 @@ module.exports = preset.btcSubmitReserve({ port: 10225, coin: "BTRM", blobType: 
     rpc: rpc.btc({
         createBlockTemplate: btcTemplate.rtm,
         rewardMultiplier: 100000000,
+        headerRewardMode: "sum-pool-vout",
         difficultyMultiplier: 0xFFFFFFFF
     }),
     pow: pow.cryptonight({ variant: 18 })

--- a/lib/coins/core/factories.js
+++ b/lib/coins/core/factories.js
@@ -45,11 +45,14 @@ function createProfile(spec) {
 
 function isCoinProfile(value) { return !!(value && value[COIN_PROFILE_SYMBOL] === true); }
 
-function parseBtcReward(block, config) {
+function parseBtcReward(block, config, poolAddress) {
     block.reward = 0;
     for (const vout of block.tx[0].vout) {
-        if (config.headerRewardMode === "sum-vout") {
-            if (config.rewardIgnoreAddress && vout.scriptPubKey.addresses && vout.scriptPubKey.addresses[0] === config.rewardIgnoreAddress) continue;
+        const addresses = vout.scriptPubKey && vout.scriptPubKey.addresses;
+        if (config.headerRewardMode === "sum-pool-vout") {
+            if (poolAddress && addresses && addresses.indexOf(poolAddress) !== -1) block.reward += vout.value;
+        } else if (config.headerRewardMode === "sum-vout") {
+            if (config.rewardIgnoreAddress && addresses && addresses[0] === config.rewardIgnoreAddress) continue;
             block.reward += vout.value;
         } else if (vout.value > block.reward) {
             block.reward = vout.value;
@@ -229,7 +232,7 @@ function createBtcRpc(overrides) {
     config.getAnyBlockHeaderByHash = function getAnyBlockHeaderByHash(ctx) {
         ctx.runtime.support.rpcPortDaemon2(ctx.port, "", { method: "getblock", params: [ctx.blockHash, 2] }, function onBlock(body) {
             if (!body || !body.result || !(body.result.tx instanceof Array) || body.result.tx.length < 1) return ctx.callback(true, body);
-            return ctx.callback(null, parseBtcReward(body.result, config));
+            return ctx.callback(null, parseBtcReward(body.result, config, ctx.runtime.getPoolAddress(ctx.profile)));
         }, ctx.noErrorReport);
     };
 

--- a/lib/coins/rtm.js
+++ b/lib/coins/rtm.js
@@ -6,6 +6,7 @@ module.exports = preset.btcSubmitReserve({ port: 9998, coin: "RTM", blobType: 10
     rpc: rpc.btc({
         createBlockTemplate: btcTemplate.rtm,
         rewardMultiplier: 100000000,
+        headerRewardMode: "sum-pool-vout",
         difficultyMultiplier: 0xFFFFFFFF
     }),
     pow: pow.cryptonight({ variant: 18 })

--- a/tests/pool/components/core.js
+++ b/tests/pool/components/core.js
@@ -126,6 +126,76 @@ test("pool state thread names use short master and worker prefixes", () => {
     }
 });
 
+
+test("RTM block rewards only credit outputs paid to the configured pool address", async () => {
+    const originalConfig = global.config;
+    const originalSupport = global.support;
+    const originalCoinFuncs = global.coinFuncs;
+    const originalDatabase = global.database;
+
+    try {
+        global.config = {
+            daemon: { port: 18081 },
+            general: { testnet: false },
+            pool: {
+                address: "48A1PoolAddress",
+                address_9998: "POOL_RTM_WALLET_CONFIGURED_FOR_9998"
+            },
+            pool_id: 1
+        };
+        global.database = {};
+        global.support = {
+            rpcPortDaemon2(port, _path, request, callback, suppressErrorLog) {
+                assert.equal(port, 9998);
+                assert.equal(request.method, "getblock");
+                assert.equal(suppressErrorLog, true);
+
+                const blockHash = request.params[0];
+                const vout = blockHash === "pool-output" ? [
+                    { value: 12.5, scriptPubKey: { addresses: ["POOL_RTM_WALLET_CONFIGURED_FOR_9998"] } },
+                    { value: 50, scriptPubKey: { addresses: ["NON_POOL_RECIPIENT"] } },
+                    { value: 1.25, scriptPubKey: { addresses: ["POOL_RTM_WALLET_CONFIGURED_FOR_9998"] } }
+                ] : [
+                    { value: 37.5, scriptPubKey: { addresses: ["NON_POOL_RECIPIENT"] } }
+                ];
+
+                callback({
+                    result: {
+                        hash: blockHash,
+                        height: 100,
+                        difficulty: 1,
+                        tx: [{ vout }]
+                    }
+                });
+            }
+        };
+
+        const coinFuncs = new Coin({});
+        global.coinFuncs = coinFuncs;
+
+        const poolRewardHeader = await new Promise(function getPoolReward(resolve) {
+            coinFuncs.getPortBlockHeaderByHash(9998, "pool-output", function onHeader(err, header) {
+                assert.equal(err, null);
+                resolve(header);
+            }, true);
+        });
+        assert.equal(poolRewardHeader.reward, 1375000000);
+
+        const noPoolRewardHeader = await new Promise(function getNoPoolReward(resolve) {
+            coinFuncs.getPortBlockHeaderByHash(9998, "no-pool-output", function onHeader(err, header) {
+                assert.equal(err, null);
+                resolve(header);
+            }, true);
+        });
+        assert.equal(noPoolRewardHeader.reward, 0);
+    } finally {
+        global.config = originalConfig;
+        global.support = originalSupport;
+        global.coinFuncs = originalCoinFuncs;
+        global.database = originalDatabase;
+    }
+});
+
 test("cryptonote block-header reward lookup preserves suppress flags and wallet error detail", (t, done) => {
     const originalConfig = global.config;
     const originalSupport = global.support;


### PR DESCRIPTION
### Motivation
- Fix a regression that recorded RTM/BTRM block rewards as the largest coinbase output regardless of destination, which could over-credit miners when the pool address did not receive funds.
- Restore destination-validated reward accounting so only outputs paid to the configured pool wallet are counted for payouts.

### Description
- Extended `parseBtcReward` to accept a `poolAddress` and added a new `headerRewardMode` value `sum-pool-vout` that sums only coinbase vouts whose `scriptPubKey.addresses` include the pool address.
- Pass the resolved pool address into `parseBtcReward` from the BTC RPC path so coin header parsing can validate destinations (`lib/coins/core/factories.js`).
- Enabled `headerRewardMode: "sum-pool-vout"` for RTM and BTRM profiles so those ports only credit outputs sent to the configured pool wallet (`lib/coins/rtm.js`, `lib/coins/btrm.js`).
- Added a unit test that verifies RTM only counts vouts paid to `pool.address_9998` and records zero when no pool output exists (`tests/pool/components/core.js`).

### Testing
- Ran syntax/type checks with `node --check` on the modified files and the new test file, which completed successfully.
- Attempted to run the targeted unit test `tests/pool/components/core.js` via the repository test harness, but test execution failed due to missing dependency `node-blocktemplate` in the environment so the runtime test could not complete.
- Attempted to install dependencies with `npm install --no-package-lock`, but the install was blocked by the environment/registry returning `403 Forbidden` for `crypto-js`, preventing full test execution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0ba54e9dfc8321b17355dc2a8218fc)