### PR TITLE
Fix RTM/BTRM coinbase reward selection

### DIFF
--- a/lib/coins/btrm.js
+++ b/lib/coins/btrm.js
@@ -5,6 +5,7 @@ module.exports = preset.btcSubmitReserve({ port: 10225, coin: "BTRM", blobType: 
     blob: blob.rtm(),
     rpc: rpc.btc({
         createBlockTemplate: btcTemplate.rtm,
+        headerRewardMode: "pool-address-vout",
         rewardMultiplier: 100000000,
         difficultyMultiplier: 0xFFFFFFFF
     }),

--- a/lib/coins/core/factories.js
+++ b/lib/coins/core/factories.js
@@ -45,12 +45,23 @@ function createProfile(spec) {
 
 function isCoinProfile(value) { return !!(value && value[COIN_PROFILE_SYMBOL] === true); }
 
-function parseBtcReward(block, config) {
+function getVoutAddresses(vout) {
+    if (!vout || !vout.scriptPubKey) return [];
+    if (Array.isArray(vout.scriptPubKey.addresses)) return vout.scriptPubKey.addresses;
+    if (typeof vout.scriptPubKey.address === "string") return [vout.scriptPubKey.address];
+    return [];
+}
+
+function parseBtcReward(block, config, poolAddress) {
     block.reward = 0;
     for (const vout of block.tx[0].vout) {
         if (config.headerRewardMode === "sum-vout") {
-            if (config.rewardIgnoreAddress && vout.scriptPubKey.addresses && vout.scriptPubKey.addresses[0] === config.rewardIgnoreAddress) continue;
+            if (config.rewardIgnoreAddress && getVoutAddresses(vout)[0] === config.rewardIgnoreAddress) continue;
             block.reward += vout.value;
+        } else if (config.headerRewardMode === "pool-address-vout") {
+            if (poolAddress && getVoutAddresses(vout).indexOf(poolAddress) !== -1) {
+                block.reward += vout.value;
+            }
         } else if (vout.value > block.reward) {
             block.reward = vout.value;
         }
@@ -229,7 +240,7 @@ function createBtcRpc(overrides) {
     config.getAnyBlockHeaderByHash = function getAnyBlockHeaderByHash(ctx) {
         ctx.runtime.support.rpcPortDaemon2(ctx.port, "", { method: "getblock", params: [ctx.blockHash, 2] }, function onBlock(body) {
             if (!body || !body.result || !(body.result.tx instanceof Array) || body.result.tx.length < 1) return ctx.callback(true, body);
-            return ctx.callback(null, parseBtcReward(body.result, config));
+            return ctx.callback(null, parseBtcReward(body.result, config, ctx.runtime.getPoolAddress(ctx.profile)));
         }, ctx.noErrorReport);
     };
 

--- a/lib/coins/rtm.js
+++ b/lib/coins/rtm.js
@@ -5,6 +5,7 @@ module.exports = preset.btcSubmitReserve({ port: 9998, coin: "RTM", blobType: 10
     blob: blob.rtm(),
     rpc: rpc.btc({
         createBlockTemplate: btcTemplate.rtm,
+        headerRewardMode: "pool-address-vout",
         rewardMultiplier: 100000000,
         difficultyMultiplier: 0xFFFFFFFF
     }),

--- a/tests/pool/coin/basics.js
+++ b/tests/pool/coin/basics.js
@@ -170,6 +170,45 @@ test("BlockTemplate uses the SAL blob marker when daemon reserved offset is stal
     assert.equal(blockTemplate.reserved_offset, prefix.length + 2);
 });
 
+test("RTM/BTRM block reward uses only coinbase outputs paid to the pool address", async () => {
+    const coinFuncs = global.coinFuncs.__realCoinFuncs;
+    const poolAddress = "POOL_RTM_ADDRESS";
+    const originalRpcPortDaemon2 = global.support.rpcPortDaemon2;
+    global.config.pool.address_9998 = poolAddress;
+    global.support.rpcPortDaemon2 = function rpcPortDaemon2(port, method, params, callback) {
+        assert.equal(port, 9998);
+        assert.equal(method, "");
+        assert.deepEqual(params, { method: "getblock", params: ["rtm-block", 2] });
+        callback({
+            result: {
+                difficulty: 2,
+                tx: [{
+                    vout: [
+                        { n: 0, value: 12.5, scriptPubKey: { addresses: [poolAddress] } },
+                        { n: 1, value: 1.25, scriptPubKey: { addresses: ["SMARTNODE_ADDRESS"] } },
+                        { n: 3, value: 100, scriptPubKey: { addresses: ["GOVERNANCE_ADDRESS"] } }
+                    ]
+                }]
+            }
+        });
+    };
+
+    try {
+        const header = await new Promise((resolve, reject) => {
+            coinFuncs.getPortAnyBlockHeaderByHash(9998, "rtm-block", true, (err, body) => {
+                if (err) return reject(new Error("unexpected RTM block header error"));
+                return resolve(body);
+            });
+        });
+
+        assert.equal(header.reward, 1250000000);
+        assert.equal(header.difficulty, 2 * 0xFFFFFFFF);
+    } finally {
+        global.support.rpcPortDaemon2 = originalRpcPortDaemon2;
+        delete global.config.pool.address_9998;
+    }
+});
+
 test("BlockTemplate derives dual-main candidate difficulty from the lowest chain difficulty", () => {
     const coinFuncs = global.coinFuncs.__realCoinFuncs;
     const originalGetAuxChainXTM = global.coinFuncs.getAuxChainXTM;


### PR DESCRIPTION
### Motivation
- RTM/BTRM header parsing could pick the largest coinbase vout regardless of recipient address, allowing non-pool smartnode/governance/dev outputs to be treated as the pool reward and inflate miner credits.
- The change restores conservative reward selection that only counts coinbase outputs actually paid to the configured pool address for affected BTC-style profiles.

### Description
- Add `getVoutAddresses` helper and extend `parseBtcReward` to accept an optional `poolAddress` and support a new `headerRewardMode` value `pool-address-vout` that sums only vouts payable to the pool address. (modified: `lib/coins/core/factories.js`)
- Pass the pool address into BTC-style reward parsing so address-aware selection can be performed when computing header rewards. (modified: `lib/coins/core/factories.js`)
- Configure RTM and BTRM profiles to use `headerRewardMode: "pool-address-vout"` so only coinbase outputs sent to the configured pool address contribute to the reported reward. (modified: `lib/coins/rtm.js`, `lib/coins/btrm.js`)
- Add a regression test that mocks an RTM block with a smaller pool-paid vout and a larger non-pool vout and asserts the pool-paid output is chosen. (added: `tests/pool/coin/basics.js`)

### Testing
- Ran syntax checks: `node --check lib/coins/core/factories.js && node --check lib/coins/rtm.js && node --check lib/coins/btrm.js && node --check tests/pool/coin/basics.js`, which completed successfully. 
- Attempted the targeted unit run `npm test -- --test-name-pattern="RTM/BTRM block reward"`, but the test run failed due to missing test dependency `protocol-buffers` in the environment. 
- Attempted `npm install` to fetch dependencies, but installation is blocked by the environment/npm registry returning `403 Forbidden` for a dependency (`crypto-js`), so full test execution could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0ba5996434832195e4f98cedf5aefe)