### PR TITLE
Normalize `headerRewardMode` to `sum-pool-vout` for several coin configs

### DIFF
--- a/lib/coins/btrm.js
+++ b/lib/coins/btrm.js
@@ -5,9 +5,8 @@ module.exports = preset.btcSubmitReserve({ port: 10225, coin: "BTRM", blobType: 
     blob: blob.rtm(),
     rpc: rpc.btc({
         createBlockTemplate: btcTemplate.rtm,
-        headerRewardMode: "pool-address-vout",
-        rewardMultiplier: 100000000,
         headerRewardMode: "sum-pool-vout",
+        rewardMultiplier: 100000000,
         difficultyMultiplier: 0xFFFFFFFF
     }),
     pow: pow.cryptonight({ variant: 18 })

--- a/lib/coins/rtm.js
+++ b/lib/coins/rtm.js
@@ -5,9 +5,8 @@ module.exports = preset.btcSubmitReserve({ port: 9998, coin: "RTM", blobType: 10
     blob: blob.rtm(),
     rpc: rpc.btc({
         createBlockTemplate: btcTemplate.rtm,
-        headerRewardMode: "pool-address-vout",
-        rewardMultiplier: 100000000,
         headerRewardMode: "sum-pool-vout",
+        rewardMultiplier: 100000000,
         difficultyMultiplier: 0xFFFFFFFF
     }),
     pow: pow.cryptonight({ variant: 18 })

--- a/lib/coins/rvn.js
+++ b/lib/coins/rvn.js
@@ -7,7 +7,7 @@ module.exports = preset.directReserve({ port: 8766, coin: "RVN", blobType: 101, 
     minerAlgoAliases: { kawpow: ["kawpow4"] },
     rpc: rpc.btc({
         createBlockTemplate: btcTemplate.raven,
-        headerRewardMode: "sum-vout",
+        headerRewardMode: "sum-pool-vout",
         rewardMultiplier: 100000000
     }),
     pow: pow.kawpow()

--- a/lib/coins/xna.js
+++ b/lib/coins/xna.js
@@ -7,7 +7,7 @@ module.exports = preset.directReserve({ port: 19001, coin: "XNA", blobType: 101,
     minerAlgoAliases: { kawpow: ["kawpow4"] },
     rpc: rpc.btc({
         createBlockTemplate: btcTemplate.raven,
-        headerRewardMode: "sum-vout",
+        headerRewardMode: "sum-pool-vout",
         rewardMultiplier: 100000000
     }),
     pow: pow.kawpow(),


### PR DESCRIPTION
### Motivation
- Standardize RPC `headerRewardMode` across BTC-style coin configurations to ensure consistent reward VOUT handling for pooled payouts.
- Replace inconsistent modes (`pool-address-vout` and `sum-vout`) with the unified `sum-pool-vout` value.

### Description
- Changed `rpc.headerRewardMode` to `"sum-pool-vout"` in `lib/coins/btrm.js` and `lib/coins/rtm.js`, preserving `rewardMultiplier` and other settings.
- Changed `rpc.headerRewardMode` to `"sum-pool-vout"` in `lib/coins/rvn.js` and `lib/coins/xna.js` (was `"sum-vout"`).
- No other behavioral changes to `pow`, `difficultyMultiplier`, or `rewardMultiplier` values.

### Testing
- Ran the project's automated test suite with `npm test` and the linter with `npm run lint`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0e2333159c8321b9b9781106a3a4f2)