### PR TITLE
Fix TRTL PoW profile (use Argon2/Chukwa v2)

### DIFF
--- a/lib/coins/trtl.js
+++ b/lib/coins/trtl.js
@@ -1,12 +1,11 @@
 "use strict";
 const { pool, pow, preset } = require("./core/factories.js");
 
-module.exports = preset.cryptonoteHeader({ port: 11898, coin: "TRTL", blobType: 2, algo: "cn-pico/trtl", blobTypeName: "forknote2",
+module.exports = preset.cryptonoteHeader({ port: 11898, coin: "TRTL", blobType: 2, algo: "argon2/chukwav2", blobTypeName: "forknote2",
     pool: pool.standard({
         acceptSubmittedBlock: pool.submitAccept.accepted202String,
         submitBlockRpc: pool.blockSubmit.httpBlockBody
     }),
-    minerAlgoAliases: { "cn-pico/trtl": ["cn-pico"] },
-    pow: pow.cryptonightPico(),
-    perf: { aliases: ["cn-pico", "cn-pico/trtl"] }
+    pow: pow.argon2({ variant: 2 }),
+    perf: { aliases: ["argon2/chukwav2", "chukwav2"] }
 });

--- a/tests/pool/coin/basics.js
+++ b/tests/pool/coin/basics.js
@@ -248,17 +248,49 @@ test("convertAlgosToCoinPerf preserves the expected per-coin algo aliases", () =
     const coinFuncs = global.coinFuncs.__realCoinFuncs;
     const perf = coinFuncs.convertAlgosToCoinPerf({
         "rx/0": 100,
-        "cn-pico/trtl": 200,
+        "argon2/chukwav2": 200,
         c29: 300,
         kawpow4: 400,
         etchash: 500
     });
 
     assert.equal(perf[""], 100);
+    assert.equal(perf.TRTL, 200);
+    assert.equal(perf.LTHN, 200);
     assert.equal(perf["SAL"], 100);
     assert.equal(perf["XTM-C"], 300);
     assert.equal(perf["XNA"], 400);
     assert.equal(perf["ETC"], 500);
+});
+
+test("TRTL profile verifies shares with Argon2/Chukwa variant 2", () => {
+    const loadRegistry = require("../../../lib/coins/core/registry.js");
+    const profile = loadRegistry().profilesByPort[11898];
+    const calls = [];
+    const runtime = {
+        powHash: {
+            argon2(buffer, variant) {
+                calls.push({ algorithm: "argon2", buffer: Buffer.from(buffer), variant });
+                return Buffer.from("11".repeat(32), "hex");
+            },
+            cryptonight_pico() {
+                throw new Error("TRTL must not verify shares with cryptonight_pico");
+            }
+        }
+    };
+
+    assert.equal(profile.algo, "argon2/chukwav2");
+    assert.equal(profile.pow.variant, 2);
+    assert.deepEqual(profile.perf.aliases, ["argon2/chukwav2", "chukwav2"]);
+
+    const convertedBlob = Buffer.from("aabbccdd", "hex");
+    const hash = profile.pow.hashBuff({ convertedBlob, runtime });
+
+    assert.equal(hash.toString("hex"), "11".repeat(32));
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].algorithm, "argon2");
+    assert.equal(calls[0].variant, 2);
+    assert.deepEqual(calls[0].buffer, convertedBlob);
 });
 
 test("shared blob types no longer collapse to the last loaded coin profile", () => {


### PR DESCRIPTION
### Motivation
- A refactor accidentally registered the TRTL port `11898` with the `cn-pico/trtl` algorithm and `cryptonight_pico` verifier, which caused share verification to trust the wrong PoW and allowed invalid TRTL work to be credited.
- The change restores the historical TRTL PoW (Argon2/Chukwav2 variant 2) so that shares submitted on port `11898` are validated against the correct algorithm and cannot be abused to dilute payout accounting.

### Description
- Change `lib/coins/trtl.js` to set `algo: "argon2/chukwav2"` and `pow: pow.argon2({ variant: 2 })` while preserving existing pool submit and blob settings in the profile via `preset.cryptonoteHeader`.
- Update TRTL `perf` aliases to `["argon2/chukwav2", "chukwav2"]` so performance mapping aligns with the restored algorithm.
- Add a focused regression test in `tests/pool/coin/basics.js` that asserts the TRTL profile resolves to Argon2/Chukwa variant 2 and invokes `argon2` rather than `cryptonight_pico` when calling the profile `pow.hashBuff`.
- Keep the change minimal and coin-local so other coin profiles and pool logic are unaffected.

### Testing
- Ran syntax checks with `node --check lib/coins/trtl.js` which succeeded.
- Ran `node --check tests/pool/coin/basics.js` and executed a focused Node assertion that invoked the registry/profile `pow.hashBuff` to confirm it calls `argon2` with `variant: 2`, which succeeded.
- Attempted to run the full test harness (`node --require ./tests/common/test_output_buffer.js --test ... tests/pool/coin/basics.js`) but the full harness could not complete due to missing native test dependencies (`node-powhash`, `protocol-buffers`) because `npm install` was blocked by a registry `403`, preventing a full test run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0b927382e483218f5b3537e4673edf)