### PR TITLE
Fix verifier counter leak during stale queue cleanup

### DIFF
--- a/lib/coins/index.js
+++ b/lib/coins/index.js
@@ -197,6 +197,7 @@ if (global.config.verify_shares_host) global.config.verify_shares_host.forEach(f
             if (!(d.miner_address in miner_address)) miner_address[d.miner_address] = 1;
             else ++miner_address[d.miner_address];
             if (Date.now() - d.time <= 60 * 1000) return false;
+            if (d.miner_address in miner_address_verify) --miner_address_verify[d.miner_address];
             d.cb(null);
             return true;
         });


### PR DESCRIPTION
### Motivation
- The age-based verifier queue cleanup removed expired pending verification tasks without decrementing `miner_address_verify`, which could let attackers leak per-address pending counts and suppress future verifications for a victim payout address.

### Description
- Decrement `miner_address_verify` when an expired pending task is removed during the verify queue cleanup in `lib/coins/index.js`, preserving the existing behavior of calling the task callback with `null`.
- This is implemented as a single-line insertion to balance the per-address in-flight counter for tasks that never reach worker start.

### Testing
- No automated tests were executed as part of this rollout.
- The patch was validated by inspecting the `git diff` for `lib/coins/index.js` and committing the change successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0f87bae348832198ffacc10821abe2)