### PR TITLE
Fix merged-mined parent template refresh when child template changes

### DIFF
--- a/lib/pool/templates.js
+++ b/lib/pool/templates.js
@@ -346,7 +346,10 @@ module.exports = function createTemplateManager(deps) {
     function setNewBlockTemplate(template) {
         const coin = template.coin;
         const previousTemplate = activeBlockTemplates[coin];
-        if (previousTemplate && previousTemplate.idHash === template.idHash) return;
+        if (previousTemplate && previousTemplate.idHash === template.idHash) {
+            const isMmParentTemplate = typeof template.parent_blocktemplate_blob === "string";
+            if (!isMmParentTemplate || previousTemplate.parent_blocktemplate_blob === template.parent_blocktemplate_blob) return;
+        }
         let isExtraCheck = false;
         if (previousTemplate) {
             previousTemplate.timeoutTime = Date.now() + 4 * 1000;


### PR DESCRIPTION
### Motivation
- An early-return in `setNewBlockTemplate` compared only `idHash` and could skip rebuilding a merged-mined parent template that had a newly-derived `parent_blocktemplate_blob`, leaving parent templates referencing stale child state.
- The change restores correctness for merged-mining refreshes while keeping the fast-path for truly unchanged templates.

### Description
- Updated `lib/pool/templates.js` in `setNewBlockTemplate` to skip the early return when the incoming template is a merged-mined parent (has `parent_blocktemplate_blob`) and the `parent_blocktemplate_blob` differs from the active template, forcing reconstruction of the `BlockTemplate` in that case.
- Preserved the unchanged-template fast path for non-MM templates and for MM templates whose `parent_blocktemplate_blob` is unchanged.
- No other behavioral changes; the fix is a minimal guard around the existing `idHash` equality check.

### Testing
- Loaded the modified module with `node -e "require('./lib/pool/templates.js')"` which completed successfully.
- No full test-suite run was performed in this environment due to external dependency constraints, so only the basic module load check was executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0f87ba7d288321951e3d4bb31e0117)