### PR TITLE
Avoid xtrace in deploy install paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Run the installer as `root`:
 
 ```bash
 curl -L https://raw.githubusercontent.com/MoneroOcean/nodejs-pool/master/deployment/deploy.bash | \
-WWW_DNS=pool.example.com API_DNS=api.pool.example.com CF_DNS_API_TOKEN="Cloudflare API Token" CERTBOT_EMAIL=ops@example.com bash -x
+WWW_DNS=pool.example.com API_DNS=api.pool.example.com CF_DNS_API_TOKEN="Cloudflare API Token" CERTBOT_EMAIL=ops@example.com bash -s
 ```
 
 `WWW_DNS`, `API_DNS`, and `CERTBOT_EMAIL` default to the MoneroOcean production values if omitted. Set them explicitly for any non-production install.
@@ -94,10 +94,10 @@ pm2 save
 For a leaf-only install:
 
 ```bash
-curl -L https://raw.githubusercontent.com/MoneroOcean/nodejs-pool/master/deployment/leaf.bash | bash -x
+curl -L https://raw.githubusercontent.com/MoneroOcean/nodejs-pool/master/deployment/leaf.bash | bash
 ```
 
-Set `TARI_RELEASE_TAG` before `bash -x` to use a different Tari source tag on leaf nodes.
+Set `TARI_RELEASE_TAG` before `bash` to use a different Tari source tag on leaf nodes.
 
 After install, update the leaf config so it points at the main pool infrastructure, then start the `pool` module on that node.
 

--- a/deployment/deploy.bash
+++ b/deployment/deploy.bash
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 
 NODEJS_VERSION="${NODEJS_VERSION:-v24.15.0}"
 WWW_DNS="${WWW_DNS:-moneroocean.stream}"

--- a/deployment/leaf.bash
+++ b/deployment/leaf.bash
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 
 NODEJS_VERSION="${NODEJS_VERSION:-v24.15.0}"
 TARI_RELEASE_TAG="${TARI_RELEASE_TAG:-v5.3.1}"


### PR DESCRIPTION
### Motivation
- Prevent accidental disclosure of deployment secrets when operators follow the README curl-pipe install examples by disabling `bash` xtrace (`-x`).
- Preserve existing error-fail behavior while removing the explicit advice and script flags that cause secret values (Cloudflare API token, generated MySQL root password, API keys) to be printed to stderr/logs.

### Description
- Replace the README curl-pipe single-server example to use `bash -s` instead of `bash -x` and change the leaf install example to pipe into plain `bash` instead of `bash -x`.
- Change the `deploy.bash` and `leaf.bash` shebangs from `#!/bin/bash -ex` to `#!/bin/bash -e` so scripts still fail fast but do not enable xtrace by default.
- Preserve all deployment logic and defaults; no secret-handling code or behavior was otherwise altered.

### Testing
- Ran `rg -n "bash -x|set -x|^#!/bin/bash -.*x" README.md deployment/deploy.bash deployment/leaf.bash` to verify `-x` recommendations and shebangs were removed, and the search returned no remaining `-x` occurrences in the install paths.
- Run `bash -n deployment/deploy.bash` and `bash -n deployment/leaf.bash` for syntax checks which completed without errors.
- Executed `git diff --check` to ensure no trailing whitespace or diff-check issues remained, which reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0b985576088321b9c5bc084ff68bbd)