### PR TITLE
Fix email reset script to preserve payout lock state

### DIFF
--- a/user_scripts/user_email_reset.js
+++ b/user_scripts/user_email_reset.js
@@ -5,7 +5,7 @@ const user = cli.arg("user", "Please specify user address to reset");
 
 cli.init(function() {
 	userDb.requireExistingUser(user, "User settings row does not exist").then(function () {
-		return userDb.runLoggedQuery("DELETE FROM users WHERE username = ?", [user], "DELETE FROM users WHERE username = " + user);
+		return userDb.runLoggedQuery("UPDATE users SET email = NULL, pass = NULL WHERE username = ?", [user], "UPDATE users SET email = NULL, pass = NULL WHERE username = " + user);
 	}).then(function () {
 		userDb.finish("Done. Please restart the miner or wait for it to reconnect and submit a valid share to set email/password again.");
 	});


### PR DESCRIPTION
### Motivation
- The management script `user_scripts/user_email_reset.js` previously executed `DELETE FROM users WHERE username = ?`, which removed `payout_threshold` and `payout_threshold_lock` stored on the same row and could allow bypassing of admin-enforced payout locks via the public `/user/updateThreshold` flow. 

### Description
- Replace the destructive query with a targeted update: `UPDATE users SET email = NULL, pass = NULL WHERE username = ?` so the `users` row is preserved and `payout_threshold`/`payout_threshold_lock` remain intact. 

### Testing
- No automated tests were executed for this one-line management-script fix; the change was verified by inspecting the updated file `user_scripts/user_email_reset.js` and confirming the SQL now only clears `email` and `pass`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0f87ba1e4083218c57266e75e1e222)