### PR TITLE
Fix root command injection in Tari updater build step

### DIFF
--- a/deployment/update_daemons.bash
+++ b/deployment/update_daemons.bash
@@ -54,6 +54,6 @@ sudo USE_SINGLE_BUILDDIR=1 nice make release
 echo "Building Tari $TARI_RELEASE_TAG"
 ensure_rust_toolchain
 checkout_repo_ref "$TARI_REPO_URL" /usr/local/src/tari "$TARI_RELEASE_TAG"
-sudo bash -lc ". /root/.cargo/env && cd /usr/local/src/tari && TARI_TARGET_NETWORK=$TARI_NETWORK cargo build --release -p minotari_node -p minotari_merge_mining_proxy"
+sudo TARI_TARGET_NETWORK="$TARI_NETWORK" bash -lc ". /root/.cargo/env && cd /usr/local/src/tari && cargo build --release -p minotari_node -p minotari_merge_mining_proxy"
 
 echo "Done. Restart when ready: sudo systemctl restart monero xtm xtm_mm"


### PR DESCRIPTION
### Motivation
- Prevent shell command injection from a caller-controlled `TARI_NETWORK` value that was previously expanded unquoted inside a `sudo bash -lc` command string in `deployment/update_daemons.bash`.

### Description
- Replace the vulnerable inline expansion `TARI_TARGET_NETWORK=$TARI_NETWORK` inside the `bash -lc` string with an environment assignment passed to `sudo` as `sudo TARI_TARGET_NETWORK="$TARI_NETWORK" bash -lc ". /root/.cargo/env && cd /usr/local/src/tari && cargo build --release -p minotari_node -p minotari_merge_mining_proxy"` in `deployment/update_daemons.bash` to avoid shell metacharacter parsing.

### Testing
- Ran `bash -n deployment/update_daemons.bash` to verify syntax and reviewed the `git diff` to confirm the intended one-line change, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0f87ba4c588321b51ee22d963618ae)