### PR TITLE
Validate Tari memory env values before writing systemd units

### DIFF
--- a/deployment/deploy.bash
+++ b/deployment/deploy.bash
@@ -93,6 +93,19 @@ TARI_MEMORY_HIGH="${TARI_MEMORY_HIGH:-$(default_tari_memory_high)}"
 TARI_MEMORY_SWAP_MAX="${TARI_MEMORY_SWAP_MAX:-768M}"
 TARI_MM_MEMORY_HIGH="${TARI_MM_MEMORY_HIGH:-1200M}"
 TARI_MM_MEMORY_SWAP_MAX="${TARI_MM_MEMORY_SWAP_MAX:-384M}"
+validate_systemd_memory_limit() {
+  local value="$1"
+  local name="$2"
+  if [[ ! "$value" =~ ^(infinity|max|[0-9]+([.][0-9]+)?[KMGTPE]?)$ ]]; then
+    echo "Invalid $name value: $value" >&2
+    exit 1
+  fi
+}
+
+validate_systemd_memory_limit "$TARI_MEMORY_HIGH" TARI_MEMORY_HIGH
+validate_systemd_memory_limit "$TARI_MEMORY_SWAP_MAX" TARI_MEMORY_SWAP_MAX
+validate_systemd_memory_limit "$TARI_MM_MEMORY_HIGH" TARI_MM_MEMORY_HIGH
+validate_systemd_memory_limit "$TARI_MM_MEMORY_SWAP_MAX" TARI_MM_MEMORY_SWAP_MAX
 HUGEPAGES_GROUP="${HUGEPAGES_GROUP:-hugepages}"
 MONERO_RANDOMX_HUGEPAGES="${MONERO_RANDOMX_HUGEPAGES:-384}"
 MONERO_LOG_CATEGORIES="${MONERO_LOG_CATEGORIES:-*:ERROR,cn:ERROR,blockchain:ERROR,verify:ERROR}"

--- a/deployment/leaf.bash
+++ b/deployment/leaf.bash
@@ -82,6 +82,19 @@ TARI_MEMORY_HIGH="${TARI_MEMORY_HIGH:-$(default_tari_memory_high)}"
 TARI_MEMORY_SWAP_MAX="${TARI_MEMORY_SWAP_MAX:-768M}"
 TARI_MM_MEMORY_HIGH="${TARI_MM_MEMORY_HIGH:-1200M}"
 TARI_MM_MEMORY_SWAP_MAX="${TARI_MM_MEMORY_SWAP_MAX:-384M}"
+validate_systemd_memory_limit() {
+  local value="$1"
+  local name="$2"
+  if [[ ! "$value" =~ ^(infinity|max|[0-9]+([.][0-9]+)?[KMGTPE]?)$ ]]; then
+    echo "Invalid $name value: $value" >&2
+    exit 1
+  fi
+}
+
+validate_systemd_memory_limit "$TARI_MEMORY_HIGH" TARI_MEMORY_HIGH
+validate_systemd_memory_limit "$TARI_MEMORY_SWAP_MAX" TARI_MEMORY_SWAP_MAX
+validate_systemd_memory_limit "$TARI_MM_MEMORY_HIGH" TARI_MM_MEMORY_HIGH
+validate_systemd_memory_limit "$TARI_MM_MEMORY_SWAP_MAX" TARI_MM_MEMORY_SWAP_MAX
 HUGEPAGES_GROUP="${HUGEPAGES_GROUP:-hugepages}"
 MONERO_RANDOMX_HUGEPAGES="${MONERO_RANDOMX_HUGEPAGES:-384}"
 MONERO_LOG_CATEGORIES="${MONERO_LOG_CATEGORIES:-*:ERROR,cn:ERROR,blockchain:ERROR,verify:ERROR}"


### PR DESCRIPTION
### Motivation
- The deployment scripts `deployment/deploy.bash` and `deployment/leaf.bash` previously interpolated environment-controlled memory values directly into expanding systemd unit heredocs, allowing newline-based injection of unit directives. 
- The change adds validation to ensure only safe systemd memory-size formats are accepted before values are written into root-owned unit files.

### Description
- Add a `validate_systemd_memory_limit()` function to `deployment/deploy.bash` and `deployment/leaf.bash` to check memory values. 
- The validator only permits `infinity`, `max`, or numeric values with an optional decimal and a unit suffix (e.g. `12G`, `768M`) via a strict regex. 
- Call the validator immediately after the four Tari memory-related variables (`TARI_MEMORY_HIGH`, `TARI_MEMORY_SWAP_MAX`, `TARI_MM_MEMORY_HIGH`, `TARI_MM_MEMORY_SWAP_MAX`) are initialized so the script fails fast on invalid input and prevents unit-file injection while preserving existing deployment behavior.

### Testing
- Verified script syntax with `bash -n deployment/deploy.bash && bash -n deployment/leaf.bash`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0f87ba47cc8321a77c23188ea43ea3)