### PR TITLE
Harden payment exclusivity checks after advisory-lock connection loss

### DIFF
--- a/lib/payments/processor.js
+++ b/lib/payments/processor.js
@@ -109,7 +109,9 @@ module.exports = function createPaymentsProcessor(ctx, state, deps) {
     }
 
     async function checkExclusiveAccess() {
-        if (!state.lockConnection || typeof verifyExclusiveAccess !== "function") return true;
+        if (state.isFailStop) return false;
+        if (typeof verifyExclusiveAccess !== "function") return true;
+        if (!state.lockConnection) return false;
         return await verifyExclusiveAccess();
     }
 


### PR DESCRIPTION
### Motivation
- Prevent a race where the advisory-lock connection close clears `state.lockConnection` but `checkExclusiveAccess` treats a missing connection as success, allowing payout submission after lock loss and risking split-brain payouts.

### Description
- Change `checkExclusiveAccess` in `lib/payments/processor.js` to return `false` when `state.isFailStop` or when `state.lockConnection` is missing, while preserving the prior behavior when `verifyExclusiveAccess` is not provided.

### Testing
- Ran the payments runtime tests via `node --require ./tests/common/test_output_buffer.js --test --test-reporter=./tests/common/spec_reporter.js --test-concurrency=1 tests/payments/runtime.js`, but the run failed due to a missing dependency (`debug`: `MODULE_NOT_FOUND`), so the test suite could not be validated in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0f87babf748321b35b0f8856c7cda4)