### PR TITLE
Require explicit Tari wallet address in leaf install

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,11 @@ pm2 save
 For a leaf-only install:
 
 ```bash
-curl -L https://raw.githubusercontent.com/MoneroOcean/nodejs-pool/master/deployment/leaf.bash | bash -x
+TARI_WALLET_PAYMENT_ADDRESS=<your_tari_wallet_address> \
+  curl -L https://raw.githubusercontent.com/MoneroOcean/nodejs-pool/master/deployment/leaf.bash | bash -x
 ```
 
+`TARI_WALLET_PAYMENT_ADDRESS` is required so Tari merge-mining rewards are paid to a wallet you control.
 Set `TARI_RELEASE_TAG` before `bash -x` to use a different Tari source tag on leaf nodes.
 
 After install, update the leaf config so it points at the main pool infrastructure, then start the `pool` module on that node.

--- a/deployment/leaf.bash
+++ b/deployment/leaf.bash
@@ -9,7 +9,7 @@ TARI_USER="${TARI_USER:-taridaemon}"
 TARI_HOME="${TARI_HOME:-/home/$TARI_USER}"
 TARI_CONFIG_PATCH_URL="${TARI_CONFIG_PATCH_URL:-https://raw.githubusercontent.com/MoneroOcean/nodejs-pool/master/deployment/patch-tari-config.sh}"
 TARI_EXTERNAL_IP="${TARI_EXTERNAL_IP:-}"
-TARI_WALLET_PAYMENT_ADDRESS="${TARI_WALLET_PAYMENT_ADDRESS:-12FrDe5cUauXdMeCiG1DU3XQZdShjFd9A4p9agxsddVyAwpmz73x4b2Qdy5cPYaGmKNZ6g1fbCASJpPxnjubqjvHDa5}"
+TARI_WALLET_PAYMENT_ADDRESS="${TARI_WALLET_PAYMENT_ADDRESS:-}"
 
 if [ "$(id -u)" -ne 0 ]; then
   echo "Please run this script as root"
@@ -175,6 +175,10 @@ patch_tari_config() {
   chmod 755 "$patcher"
   if [ -n "$TARI_EXTERNAL_IP" ]; then
     args+=("--base-node-grpc-ip" "$TARI_EXTERNAL_IP")
+  fi
+  if [ -z "$TARI_WALLET_PAYMENT_ADDRESS" ]; then
+    echo "TARI_WALLET_PAYMENT_ADDRESS must be set to your Tari wallet payment address" >&2
+    return 1
   fi
   args+=("--wallet-payment-address" "$TARI_WALLET_PAYMENT_ADDRESS")
   "$patcher" "${args[@]}"


### PR DESCRIPTION
### Motivation
- Prevent silent redirection of Tari/XTM merge-mining rewards by removing a repository-default wallet address in the leaf installer.
- Ensure operators must explicitly provide their own `TARI_WALLET_PAYMENT_ADDRESS` so deployments fail closed instead of configuring a third-party payout address.

### Description
- Removed the hardcoded default `TARI_WALLET_PAYMENT_ADDRESS` in `deployment/leaf.bash` so the variable defaults to empty unless provided by the operator.
- Added a guard in `patch_tari_config()` in `deployment/leaf.bash` that prints an error and returns non-zero when `TARI_WALLET_PAYMENT_ADDRESS` is unset, preventing the patcher from being called with an implicit address.
- Updated the README leaf-install snippet to require setting `TARI_WALLET_PAYMENT_ADDRESS` in the documented one-liner and added a short note explaining why it is required.

### Testing
- Performed a shell syntax check with `bash -n deployment/leaf.bash deployment/patch-tari-config.sh`, which succeeded.
- No automated unit tests were modified; this change is limited to deployment scripts and documentation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0f87ba5a248321975ccc0daa047b48)