### PR TITLE
Bound long_runner cleanup de-dup memory to LMDB batch scope

### DIFF
--- a/lib/long_runner.js
+++ b/lib/long_runner.js
@@ -116,6 +116,9 @@ function cleanCacheDB() {
     function flush() {
         deletedCount += flushDeletes(cacheDb, deletes);
         updatedCount += flushStringPuts(cacheDb, updates);
+        scheduledDeletes.clear();
+        deletedWorkerFamilies.clear();
+        deletedAccountHistories.clear();
     }
 
     function queueDelete(key) {


### PR DESCRIPTION
### Motivation
- `cleanCacheDB` kept global de-duplication `Set`s for the entire DB scan which can grow unbounded on large stale caches and exhaust Node.js heap, crashing `long_runner`.

### Description
- Clear `scheduledDeletes`, `deletedWorkerFamilies`, and `deletedAccountHistories` inside `flush()` in `lib/long_runner.js` so de-duplication is limited to each LMDB batch while preserving existing batched delete/update behavior.

### Testing
- Ran `node --test tests/long_runner.js` and the `long_runner` test suite passed (all tests green).
- Ran `npm test -- tests/long_runner.js`; the `long_runner` suite passed but the overall `npm test` command failed in this environment due to a missing test dependency (`protocol-buffers`) unrelated to the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0f87bb1aa483219f866ba05c0bbdcb)