### PR TITLE
Fix delayed final reply for unauthenticated sockets

### DIFF
--- a/lib/pool/servers.js
+++ b/lib/pool/servers.js
@@ -166,7 +166,8 @@ module.exports = function createServerFactory(deps) {
                     if (!socket.writable) return;
                     socket.end(JSON.stringify(reply) + "\n");
                 };
-                if (Number.isFinite(timeoutSeconds) && timeoutSeconds > 0) {
+                const hasAuthenticatedMiner = Boolean(socket.miner_id && state.activeMiners.has(socket.miner_id));
+                if (hasAuthenticatedMiner && Number.isFinite(timeoutSeconds) && timeoutSeconds > 0) {
                     // Keep long-ban replies expensive for abusive reconnect loops while
                     // avoiding a single fixed delay that is easy to fingerprint.
                     const delayMs = Math.max(1000, Math.ceil(Math.random() * timeoutSeconds * 1000));


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated Stratum login attempts from keeping sockets open for long ban delays (e.g. 600s) by ensuring delayed final-reply shutdowns are only applied to sockets associated with an authenticated active miner.

### Description
- Added an authenticated-miner guard in `lib/pool/servers.js` so `sendReplyFinal` only uses the randomized delayed `socket.end` path when `socket.miner_id` maps to an active miner; otherwise the final reply closes the socket immediately.

### Testing
- Executed `npm test -- --runInBand`, which failed in this environment due to a missing dependency (`protocol-buffers`), so the repository test suite could not be run to completion here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0f87bab4688321910424688a1fd993)