### PR TITLE
Require wallet lookup for XWP block rewards

### DIFF
--- a/lib/coins/xwp.js
+++ b/lib/coins/xwp.js
@@ -3,7 +3,7 @@ const { pool, pow, preset, rpc } = require("./core/factories.js");
 
 module.exports = preset.grinGetBlock({ port: 19950, coin: "XWP", blobType: 8, algo: "c29", blobTypeName: "cuckaroo",
     pool: pool.grin({ jobAlgo: "cuckaroo", edgeBits: 29 }),
-    rpc: rpc.cryptonoteGetBlock({ walletRewardLookup: false }),
+    rpc: rpc.cryptonoteGetBlock(),
     pow: pow.c29s(),
     perf: { aliases: ["c29", "c29s"] }
 });


### PR DESCRIPTION
### Motivation
- Restore wallet-based miner transaction ownership proof for XWP by re-enabling the wallet reward lookup that was previously disabled for port `19950`.

### Description
- Replace `rpc.cryptonoteGetBlock({ walletRewardLookup: false })` with `rpc.cryptonoteGetBlock()` in `lib/coins/xwp.js` so XWP uses the shared cryptonote wallet-reward lookup behavior without altering other coin settings.

### Testing
- Ran `node -e "require('./lib/coins/xwp.js'); console.log('xwp ok')"` which loaded the module and exited successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0f87bae5cc8321a246a4cfb8379f3b)