### PR TITLE
Fix stale per-wallet verify throttle counter during queue pruning

### DIFF
--- a/lib/coins/index.js
+++ b/lib/coins/index.js
@@ -43,6 +43,12 @@ let shareVerifyQueue = [];
 let shareVerifyQueueErrorTime = [];
 let shareVerifyQueueErrorCount = [];
 
+function decrementMinerAddressVerify(miner_address) {
+    if (!(miner_address in miner_address_verify)) return;
+    --miner_address_verify[miner_address];
+    if (miner_address_verify[miner_address] <= 0) delete miner_address_verify[miner_address];
+}
+
 function parseVersion(match) {
     if (!match) return null;
     return [match[1], match[2], match[3] || "0"].map(function parsePart(part) {
@@ -118,7 +124,7 @@ if (global.config.verify_shares_host) global.config.verify_shares_host.forEach(f
     shareVerifyQueueErrorTime[index] = 0;
     shareVerifyQueueErrorCount[index] = 0;
     shareVerifyQueue[index] = createTaskQueue(16, function verifyShareRemote(task, queueCB) {
-        if (task.miner_address in miner_address_verify) --miner_address_verify[task.miner_address];
+        decrementMinerAddressVerify(task.miner_address);
         const cb = task.cb;
         if (Date.now() - task.time > 60 * 1000) {
             cb(null);
@@ -197,6 +203,7 @@ if (global.config.verify_shares_host) global.config.verify_shares_host.forEach(f
             if (!(d.miner_address in miner_address)) miner_address[d.miner_address] = 1;
             else ++miner_address[d.miner_address];
             if (Date.now() - d.time <= 60 * 1000) return false;
+            decrementMinerAddressVerify(d.miner_address);
             d.cb(null);
             return true;
         });


### PR DESCRIPTION
### Motivation
- Prevent a denial-of-service/accounting bug where expired remote-share verification tasks left per-wallet in-flight counters high, causing subsequent shares for that wallet to be treated as throttled and dropped.
- Ensure the new per-address `miner_address_verify` counter is consistently decremented on all queue exit paths so public wallet addresses cannot be abused to poison counters.

### Description
- Added a helper `decrementMinerAddressVerify(miner_address)` to safely decrement and remove zero/negative entries from `miner_address_verify` in `lib/coins/index.js`.
- Replaced direct counter manipulation in the verify worker with `decrementMinerAddressVerify` to centralize logic and cleanup.
- Call `decrementMinerAddressVerify` when expired verification tasks are removed by the queue prune path so pruned tasks no longer leave stale in-flight counts.
- Change is minimal and preserves existing verification queue semantics while preventing stale counters from persisting.

### Testing
- Ran `node --check lib/coins/index.js` to validate syntax and the modified file, which succeeded.
- Verified the changed file via `git status` and committed the change with the message `Fix verifier counter leak on expired queue pruning`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0f896cc6388321aa1cfd9fa1d8cc4f)