### PR TITLE
Harden share dump execution against hash command injection

### DIFF
--- a/lib/block_manager.js
+++ b/lib/block_manager.js
@@ -275,8 +275,16 @@ function createBlockManagerRuntime(options) {
         }
     }
 
+    function isCanonicalBlockHex(hash) {
+        return typeof hash === "string" && /^[0-9a-fA-F]{64}$/.test(hash);
+    }
+
     async function writeShareDump(blockHexes, shares4dump) {
         if (!shares4dump.length || !fsApi.existsSync("./block_share_dumps/process.sh")) return;
+        if (!blockHexes.length || blockHexes.some(function (blockHex) { return !isCanonicalBlockHex(blockHex); })) {
+            logError("Share dump", "skipping dump due to non-canonical block hash in " + formatHashes(blockHexes));
+            return;
+        }
         shares4dump.sort();
         shares4dump.unshift("#last_16_chars_of_xmr_address\ttimestamp\traw_share_diff\tshare_count\tshare_coin\txmr_share_diff\txmr_share_diff_paid");
         const filename = "block_share_dumps/" + blockHexes[0] + ".cvs";
@@ -295,10 +303,10 @@ function createBlockManagerRuntime(options) {
             return;
         }
         const files = blockHexes.map(function (blockHex) {
-            return " block_share_dumps/" + blockHex + ".cvs";
-        }).join("");
+            return "block_share_dumps/" + blockHex + ".cvs";
+        });
         await new Promise(function (resolve) {
-            childProcessApi.exec("./block_share_dumps/process.sh" + files, function (error, stdout, stderr) {
+            childProcessApi.execFile("./block_share_dumps/process.sh", files, function (error, stdout, stderr) {
                 if (error) {
                     logError("Share dump", "process.sh failed for " + formatHashes(blockHexes) + " with exit " + error.code);
                 } else {


### PR DESCRIPTION
### Motivation
- Prevent a command-injection vector where altblock `hash` values are concatenated into dump filenames and passed to a shell, allowing shell metacharacters to execute as the pool process user. 
- The change targets the recently-enabled PPLNS altblock dump path which forwards `block.hash` into the existing dump-processing sink. 
- Preserve normal dump processing for honest canonical block hashes while rejecting unsafe inputs.

### Description
- Added `isCanonicalBlockHex(hash)` to validate that a block hash is a 64-character hexadecimal string. 
- In `writeShareDump`, skip dump generation and log an error if any `blockHexes` entry is non-canonical or if the list is empty, preventing unsafe filenames from being written or processed. 
- Replaced shell-string construction + `child_process.exec` with `child_process.execFile` and an argument array to invoke `./block_share_dumps/process.sh` without interpretation of shell metacharacters, and normalized the file argument formatting.

### Testing
- Ran `npm test --silent` in the environment and the test run failed to start due to a missing dependency (`protocol-buffers`), so the repository test suite could not be executed here. 
- The patch is minimal and focused on input validation and safer process invocation to avoid behavioral changes for valid canonical hashes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0f896c6a208321b3affef52a5d38f7)