### PR TITLE
Validate Tor watchdog timeout env vars to prevent command injection

### DIFF
--- a/deployment/check_tor.sh
+++ b/deployment/check_tor.sh
@@ -7,6 +7,18 @@ LOCK_FILE="${TOR_WATCHDOG_LOCK:-/run/tor-watchdog.lock}"
 FORCE_RESTART_SECONDS="${TOR_FORCE_RESTART_SECONDS:-21600}"
 BOOTSTRAP_GRACE_SECONDS="${TOR_BOOTSTRAP_GRACE_SECONDS:-600}"
 
+
+validate_non_negative_integer() {
+    local name="$1"
+    local value="$2"
+    if [[ ! "$value" =~ ^[0-9]+$ ]]; then
+        printf 'Invalid %s: %q\n' "$name" "$value" >&2
+        exit 1
+    fi
+}
+
+validate_non_negative_integer "TOR_FORCE_RESTART_SECONDS" "$FORCE_RESTART_SECONDS"
+validate_non_negative_integer "TOR_BOOTSTRAP_GRACE_SECONDS" "$BOOTSTRAP_GRACE_SECONDS"
 log() {
     printf '%s %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$*" >> "$LOG_FILE"
 }


### PR DESCRIPTION
### Motivation
- The Tor watchdog `deployment/check_tor.sh` read `TOR_FORCE_RESTART_SECONDS` and `TOR_BOOTSTRAP_GRACE_SECONDS` from the environment and used them directly in Bash arithmetic comparisons, which allows Bash to evaluate arithmetic expressions and perform command substitution when the environment is attacker-controlled.  
- These values must be strictly validated as decimal integers to prevent privileged command execution via crafted environment variables.

### Description
- Added a `validate_non_negative_integer()` helper to `deployment/check_tor.sh` to enforce that a named value matches `^[0-9]+$`.  
- Validated `TOR_FORCE_RESTART_SECONDS` and `TOR_BOOTSTRAP_GRACE_SECONDS` immediately after they are sourced and fail fast with a clear error on malformed input.  
- Preserved the existing watchdog logic, logging, and restart behavior for valid numeric values.

### Testing
- Ran `bash -n deployment/check_tor.sh` to verify syntax and it passed.  
- Executed the script with a malicious payload `TOR_FORCE_RESTART_SECONDS='now[$(touch /tmp/pwned_test)]'` and confirmed the script exits with an invalid-value error and does not execute the payload (no marker file created).  
- Re-checked syntax after the patch and confirmed no regressions in parsing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0f9047a1a883219bdaf265fb4c25f0)