### PR TITLE
Restore repository-wide `core.*` ignore in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ cert*
 config.json
 
 # Generated local runtime outputs
-/core.*
+core.*
 dump
 dump_[0-9]*
 wallet_trust_*


### PR DESCRIPTION
### Motivation
- The `.gitignore` change anchored the `core.*` pattern to the repository root (`/core.*`), leaving core dump files generated in subdirectories unignored and increasing the risk of accidentally committing sensitive runtime memory dumps.

### Description
- Replaced the anchored root-only pattern `/core.*` with the repository-wide `core.*` pattern in `.gitignore` so core dump files are ignored at any depth.

### Testing
- Validated that both `core.123` and `lib/core.123` now match the ignore rule using `git check-ignore -v core.123 lib/core.123`, and confirmed the intended one-line change with `git diff -- .gitignore`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0f90494ffc8321beb74e7f5472c648)