### PR TITLE
Fix payout planner dedupe blocking eligible later balances

### DIFF
--- a/lib/payments/planner.js
+++ b/lib/payments/planner.js
@@ -178,7 +178,6 @@ module.exports = function createPaymentsPlanner(ctx, common) {
         if (row.payment_id !== null && typeof row.payment_id !== "undefined") return true;
         if (normalizePaymentId(row.payment_id) !== null) return true;
         if (seenRecipients.has(row.payment_address)) return true;
-        seenRecipients.add(row.payment_address);
         return false;
     }
 
@@ -209,11 +208,15 @@ module.exports = function createPaymentsPlanner(ctx, common) {
             const grossAmount = item.grossAmount;
             if (isIntegratedAddress(row.payment_address)) {
                 const batch = integratedBatchFor(item, threshold, customThreshold, integratedAddressThreshold);
-                if (batch) integratedBatches.push(batch);
+                if (batch) {
+                    integratedBatches.push(batch);
+                    seenRecipients.add(row.payment_address);
+                }
                 continue;
             }
             if (grossAmount >= threshold) {
                 bulkItems.push(item);
+                seenRecipients.add(row.payment_address);
             }
         }
 


### PR DESCRIPTION
### Motivation
- The payment planner marked a recipient as seen before applying eligibility checks, allowing an ineligible dust row to suppress later eligible rows for the same `payment_address` in the same planning cycle.
- This logic could cause delayed or missed automated payouts when an attacker mines a small balance to a victim address, so the fix is a minimal change to preserve functionality while removing the premature dedupe.

### Description
- Stop eagerly mutating `seenRecipients` in `shouldSkipPayoutRow` so pre-checks no longer mark addresses as seen; the change is in `lib/payments/planner.js`.
- Add `seenRecipients.add(...)` only after a row is actually accepted for payout, for both integrated batches and bulk items, so only payable rows dedupe subsequent entries.
- The change is intentionally minimal and preserves existing integrated/bulk validation and batching logic.

### Testing
- Ran the project test runner via `npm test` in this environment and it failed to start due to a missing dependency (`protocol-buffers`), so automated tests could not be executed successfully here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0f913592b883219dc36ec9ebb6acf6)