### PR TITLE
Remove Docker bridge MySQL principal with default credentials

### DIFF
--- a/deployment/base.sql
+++ b/deployment/base.sql
@@ -1,9 +1,7 @@
 CREATE DATABASE pool;
 CREATE USER pool@`127.0.0.1` IDENTIFIED WITH mysql_native_password BY '98erhfiuehw987fh23d';
-CREATE USER pool@`172.17.0.1` IDENTIFIED WITH mysql_native_password BY '98erhfiuehw987fh23d';
 CREATE USER pool@localhost IDENTIFIED WITH mysql_native_password BY '98erhfiuehw987fh23d';
 GRANT ALL ON pool.* TO pool@`127.0.0.1`;
-GRANT ALL ON pool.* TO pool@`172.17.0.1`;
 GRANT ALL ON pool.* TO pool@localhost;
 FLUSH PRIVILEGES;
 USE pool;


### PR DESCRIPTION
### Motivation
- Deployment bootstrap `deployment/base.sql` created a non-loopback MySQL principal `pool@172.17.0.1` using the repository default password which broadened privileged DB access beyond loopback and exposed sensitive tables and configuration.

### Description
- Removed the `CREATE USER pool@`172.17.0.1`` line and the corresponding `GRANT ALL ON pool.* TO pool@`172.17.0.1`` from `deployment/base.sql`, preserving the existing `127.0.0.1` and `localhost` principals.

### Testing
- Ran automated file inspections with `sed -n '1,40p' deployment/base.sql` and `nl -ba deployment/base.sql | sed -n '1,15p'` and confirmed the file no longer contains the `172.17.0.1` user or its `GRANT ALL` entry; these checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0f896dde1c8321856e344626798863)