### PR TITLE
Obfuscate miner key and coerce non-string keys in share-verify logging

### DIFF
--- a/lib/coins/index.js
+++ b/lib/coins/index.js
@@ -209,7 +209,10 @@ if (global.config.verify_shares_host) global.config.verify_shares_host.forEach(f
         });
         console.error(global.database.thread_id + "Share verify queue " + queueIndex + " state: " + queue_obj.length() + " items in the queue " + queue_obj.running() + " items being processed");
         Object.keys(miner_address).forEach(function reportMiner(key) {
-            if (miner_address[key] > 100) console.error("Too many shares from " + key + ": " + miner_address[key]);
+            if (miner_address[key] > 100) {
+                const minerKey = String(key || "");
+                console.error("Too many shares from " + minerKey.substr(minerKey.length - 10) + ": " + miner_address[key]);
+            }
         });
     }, 30 * 1000, shareVerifyQueue[index], index);
 });


### PR DESCRIPTION
### Motivation
- Avoid logging full miner addresses and prevent runtime errors when `key` is not a string while reporting share-verify queue activity.

### Description
- In `lib/coins/index.js` change the "Too many shares" log to coerce `key` via `String(key || "")` and print only the last 10 characters with `substr`, and add block braces around the `if` body.

### Testing
- No automated tests were run for this trivial logging change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0f9dfdd8708321b11c0d8f298cc4e8)