### PR TITLE
Fix disabled-coin stale-share cutoff regression

### DIFF
--- a/lib/pool/protocol.js
+++ b/lib/pool/protocol.js
@@ -656,7 +656,7 @@ module.exports = function createProtocolHandler(deps) {
             job.rewarded_difficulty = job.difficulty;
             if (state.activeBlockTemplates[job.coin].idHash === job.blockHash) {
                 const blockTemplate = state.activeBlockTemplates[job.coin];
-                if (!state.lastCoinHashFactorMM[job.coin] && Date.now() - blockTemplate.timeCreated > 60 * 60 * 1000) {
+                if (!state.lastCoinHashFactorMM[job.coin] && Date.now() - blockTemplate.timeCreated > 10 * 60 * 1000) {
                     sendReplyFinal("This algo was temporary disabled due to coin daemon issues. Consider using https://github.com/MoneroOcean/meta-miner to allow your miner auto algo switch in this case.");
                     return null;
                 }


### PR DESCRIPTION
### Motivation
- Revert a regression that increased the disabled-coin stale-template acceptance window from `10*60*1000` to `60*60*1000`, which enlarged the time miners could be credited for shares against a disabled coin and therefore risked diluting PPLNS payouts.

### Description
- Restore the disabled-coin active-template cutoff in `getSubmitBlockTemplate` by changing the guard in `lib/pool/protocol.js` from `60 * 60 * 1000` back to `10 * 60 * 1000`, so submissions against a disabled coin are rejected after 10 minutes.

### Testing
- Attempted to run the automated test suite with `npm test --silent`, but the test harness could not run in this environment due to a missing dependency (`protocol-buffers`), so no test failures related to this small change were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a10c4d3684483219c867b649719513c)