### PR TITLE
Fix verifier quarantine regression in remote share checks

### DIFF
--- a/lib/coins/index.js
+++ b/lib/coins/index.js
@@ -136,7 +136,7 @@ if (global.config.verify_shares_host) global.config.verify_shares_host.forEach(f
 
         const timer = setTimeout(function onTimeout() {
             socket.destroy();
-            if (shareVerifyQueueErrorCount[index] > 100) {
+            if (shareVerifyQueueErrorCount[index] > 10) {
                 const err_str = "Server " + global.config.hostname + " timeouted share verification to " + verify_shares_host;
                 console.error(err_str);
                 global.support.sendAdminFyi("coins:verify-share:" + verify_shares_host, "FYI: Can't verify share", err_str);
@@ -163,7 +163,7 @@ if (global.config.verify_shares_host) global.config.verify_shares_host.forEach(f
                 shareVerifyQueueErrorCount[index] = 0;
                 return return_cb(jsonOutput.result);
             } catch (_error) {
-                if (shareVerifyQueueErrorCount[index] > 100) {
+                if (shareVerifyQueueErrorCount[index] > 10) {
                     const err_str = "Server " + global.config.hostname + " got wrong JSON from " + verify_shares_host;
                     console.error(err_str);
                     global.support.sendAdminFyi("coins:verify-share:" + verify_shares_host, "FYI: Can't verify share", err_str);
@@ -176,7 +176,7 @@ if (global.config.verify_shares_host) global.config.verify_shares_host.forEach(f
 
         socket.on("error", function onError() {
             socket.destroy();
-            if (shareVerifyQueueErrorCount[index] > 100) {
+            if (shareVerifyQueueErrorCount[index] > 10) {
                 const err_str = "Server " + global.config.hostname + " got socket error from " + verify_shares_host;
                 console.error(err_str);
                 global.support.sendAdminFyi("coins:verify-share:" + verify_shares_host, "FYI: Can't verify share", err_str);
@@ -642,7 +642,7 @@ function Coin(data) {
         let max_noerr_time = null;
 
         shareVerifyQueue.forEach(function chooseQueue(queue_obj, index) {
-            if (time_now - shareVerifyQueueErrorTime[index] < 60 * 1000 && shareVerifyQueueErrorCount[index] > 100 && global.config.verify_shares_host[index] !== "127.0.0.1") return;
+            if (time_now - shareVerifyQueueErrorTime[index] < 60 * 1000 && shareVerifyQueueErrorCount[index] > 0 && global.config.verify_shares_host[index] !== "127.0.0.1") return;
             const qlength = queue_obj.length() + queue_obj.running();
             if (min_queue_size === null || qlength < min_queue_size) {
                 best_index = index;


### PR DESCRIPTION
### Motivation
- Restore the previous quarantine behavior for remote share verifiers so a recently failing verifier is not repeatedly selected and causing expensive local slow-hash fallbacks. 
- Revert the excessive alert/quarantine thresholds that delayed operator notification and allowed flapping verifiers to continue receiving work. 
- Reduce availability risk where unauthenticated miners could cause repeated local hashing by submitting shares while a remote verifier is flapping or down.

### Description
- Changed verifier failure alert thresholds in `lib/coins/index.js` back from `>100` to `>10` for the timeout, bad JSON, and socket error paths so operators are notified earlier. 
- Restored the quick quarantine policy in the verifier selection logic by skipping any host that has a recent failure in the last 60 seconds (`shareVerifyQueueErrorCount[index] > 0`), with the existing `127.0.0.1` exception preserved. 
- The single file modified is `lib/coins/index.js` where the verification queue error handling and queue selection were adjusted to prevent reselecting recently failed verifiers.

### Testing
- Ran `npm test --silent` in this environment and the test harness failed to start due to a missing dependency (`protocol-buffers`), so automated tests did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0f896c828883218947748d50aa022c)