### PR TITLE
Fix proxy miner diff calculation and unify proxy target handling in miner diff logic

### DIFF
--- a/lib/pool/miners.js
+++ b/lib/pool/miners.js
@@ -404,19 +404,25 @@ module.exports = function createMinerFactory(deps) {
             let minDiff;
             let historyTime;
             const proxyMiner = state.proxyMiners[proxyMinerName];
-            if (proxyMiner && proxyMiner.hashes / (timeNow - proxyMiner.connectTime) > miner.difficulty) {
+            const proxyTarget = 15;
+            let proxyDiff = 0;
+            if (proxyMiner) {
+                const proxyPeriod = (timeNow - proxyMiner.connectTime) / 1000;
+                if (proxyPeriod > 0) proxyDiff = proxyMiner.hashes * proxyTarget / proxyPeriod;
+            }
+            if (proxyMiner && proxyDiff > miner.difficulty) {
                 source = proxyMiner;
-                target = 15;
+                target = proxyTarget;
                 minDiff = 10 * global.config.pool.minDifficulty;
                 historyTime = 5;
             } else if (miner.payout in state.minerWallets && state.minerWallets[miner.payout].last_ver_shares >= global.config.pool.minerThrottleSharePerSec * global.config.pool.minerThrottleShareWindow) {
                 source = state.minerWallets[miner.payout];
-                target = 15;
+                target = proxyTarget;
                 minDiff = 10 * global.config.pool.minDifficulty;
                 historyTime = 5;
             } else {
                 source = miner;
-                target = miner.proxy ? 15 : global.config.pool.targetTime;
+                target = miner.proxy ? proxyTarget : global.config.pool.targetTime;
                 minDiff = miner.proxy ? 10 * global.config.pool.minDifficulty : global.config.pool.minDifficulty;
                 historyTime = 60;
             }


### PR DESCRIPTION
### Motivation
- Correct proxy miner hash-rate detection which previously mixed milliseconds and seconds and used a raw hashes/time comparison that could be incorrect.
- Ensure proxy detection compares a properly computed proxy hash-rate against `miner.difficulty` and avoids division-by-zero.
- Consolidate the hardcoded proxy target value into a single `proxyTarget` for consistent retarget behavior.

### Description
- Introduced a `proxyTarget` constant and compute `proxyDiff` as `proxyMiner.hashes * proxyTarget / proxyPeriod` with `proxyPeriod` in seconds and guarded by `proxyPeriod > 0`.
- Switched proxy detection to `if (proxyMiner && proxyDiff > miner.difficulty)` and use `proxyTarget` when assigning `target` for proxy-related branches and throttled wallets.
- Updated the `miner.proxy` branch to use `proxyTarget` as the target and left existing `minDiff` and `historyTime` logic intact while initializing `proxyDiff` to zero.

### Testing
- Ran unit tests with `npm test` and they passed.
- Ran linter with `npm run lint` and it passed.
- No automated test failures were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a10c2a609008321ac380e6a996e7af6)