### PR TITLE
Pass job into submissionKey to include proxy nonces

### DIFF
--- a/lib/pool/protocol.js
+++ b/lib/pool/protocol.js
@@ -757,7 +757,7 @@ module.exports = function createProtocolHandler(deps) {
             miner.touchProtocolActivity();
             const poolSettings = getPoolSettingsForJob(job);
             if (!validateSubmitNonce(miner, job, poolSettings)) return;
-            const nonceTest = poolSettings.submissionKey({ miner, params });
+            const nonceTest = poolSettings.submissionKey({ miner, job, params });
             const blockTemplate = getSubmitBlockTemplate(miner, job);
             if (!blockTemplate) return;
             const trackSharedTemplateNonceForShare = shouldTrackSharedTemplateNonce(job);


### PR DESCRIPTION
### Motivation
- Duplicate-share keys for proxy jobs depend on `ctx.job.usesProxyNonce`, but the submit path called `poolSettings.submissionKey({ miner, params })` without the `job`, causing valid proxy submissions that differ only in `poolNonce`/`workerNonce` to collapse to the same key and be rejected as duplicates.

### Description
- Change `handleSubmitRequest` in `lib/pool/protocol.js` to call `poolSettings.submissionKey({ miner, job, params })`, allowing `buildStandardSubmissionKey`/`buildProofSubmissionKey` to include `poolNonce`/`workerNonce` when `job.usesProxyNonce` is true and preserving prior behavior for non-proxy jobs.

### Testing
- Ran `npm test`; the test run could not complete in this environment because `protocol-buffers` is not installed (`Error: Cannot find module 'protocol-buffers'`), so automated tests did not run successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a15bf648fe8832186216b3c8b62da84)